### PR TITLE
Save and load to the database and unique Edit 😎

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -92,7 +92,7 @@ class Module extends \Canopy\Module implements \Canopy\SettingDefaults
 
     private function showList()
     {
-        return '<a class="nav-link" href="./slideshow/Show/list"><i class="fas fa-list"></i> Show list</a>';
+        return '<a class="btn btn-primary" href="./slideshow/Show/list"><i class="fas fa-list"></i> Show list</a>';
     }
 
     public static function autoloader($class_name)

--- a/boost/boost.php
+++ b/boost/boost.php
@@ -18,7 +18,7 @@
  * @license http://opensource.org/licenses/gpl-3.0.html
  */
 $proper_name = 'Slideshow';
-$version = '1.0.0';
+$version = '1.1.0';
 $register = false;
 $unregister = false;
 $import_sql = false;

--- a/boost/controlpanel.php
+++ b/boost/controlpanel.php
@@ -23,6 +23,6 @@ $link[] = array(
     'label' => 'Slideshow',
     'restricted' => TRUE,
     'url' => 'slideshow/',
-    'description' => 'Slideshow', 'Slideshow module using reveal.js.',
+    'description' => 'Slideshow', 'Slideshow module',
     'image' => 'slideshow.png',
     'tab' => 'content');

--- a/boost/update.php
+++ b/boost/update.php
@@ -1,0 +1,70 @@
+<?php
+
+use phpws2\Database;
+
+function slideshow_update(&$content, $current_version)
+{
+  $update = new slideshowUpdate($content, $current_version);
+  $content = $update->run();
+  return true;
+}
+
+class slideshowUpdate
+{
+  private $content;
+  private $cversion;
+
+  public function __construct($content, $cversion)
+  {
+    $this->content = $content;
+    $this->cversion = $cversion;
+  }
+
+  public function run()
+  {
+    // To add an update, add a case, and don't include a break;
+    switch (1) {
+      case $this->compare('1.1.0'):
+        $this->update('1.1.0');
+    }
+  }
+
+  private function compare($version)
+  {
+    return version_compare($this->cversion, $version, '<');
+  }
+
+  private function update($version)
+  {
+    $method = 'v' . str_replace('.', '_', $version);
+    $this->$method();
+  }
+
+  private function v1_1_0()
+  {
+    $db = \phpws2\Database::getDB();
+    $t = $db->addTable('ss_show');
+    $dt = new \phpws2\Database\Datatype\Varchar($t, 'content');
+    $dt->setDefault(null);
+    $dt->add();
+    $t->dropColumn('showId');
+
+    $changes[] = 'removed unnecessary field showId';
+    $changes[] = 'content now saves to the database';
+    $changes[] = 'content can now be loaded from the database';
+    $this->addContent('1.1.0', $changes);
+  }
+
+  private function addContent($version, array $changes)
+  {
+    $changes_string = implode("\n+ ", $changes);
+        $this->content[] = <<<EOF
+<pre>
+Version $version
+------------------------------------------------------
++ $changes_string
+</pre>
+EOF;
+
+  }
+}

--- a/boost/update.php
+++ b/boost/update.php
@@ -47,9 +47,7 @@ class slideshowUpdate
     $dt = new \phpws2\Database\Datatype\Varchar($t, 'content');
     $dt->setDefault(null);
     $dt->add();
-    $t->dropColumn('showId');
 
-    $changes[] = 'removed unnecessary field showId';
     $changes[] = 'content now saves to the database';
     $changes[] = 'content can now be loaded from the database';
     $this->addContent('1.1.0', $changes);

--- a/class/Controller/Show/Admin.php
+++ b/class/Controller/Show/Admin.php
@@ -59,12 +59,6 @@ class Admin extends Base
       return $this->view->edit();
     }
 
-    protected function createHtmlCommand(Request $request)
-    {
-      $show = $this->factory->create();
-      \Canopy\Server::forward('./Slideshow/Show/Edit/' . $show->id . '/?new=1');
-    }
-
     protected function postCommand(Request $request)
     {
         $show = $this->factory->post($request);
@@ -86,10 +80,8 @@ class Admin extends Base
     {
       $vars = $request->getRequestVars();
       $id = $vars['id'];
-      //echo "id: " . $id;
       return array(
         'slides'=> $this->factory->getSlides($id),
-        'id'=> $id
       );
     }
 

--- a/class/Factory/ShowFactory.php
+++ b/class/Factory/ShowFactory.php
@@ -128,11 +128,10 @@ class ShowFactory extends Base
      */
     public function getSlides($showId)
     {
-      if ($showId == null) {
+      if ($showId == null || $showId == -1) {
         throw new \Exception("ShowId is not valid: $showId", 1);
       }
       $sql = "SELECT content FROM ss_show WHERE id=:showId;";
-
       $db = Database::getDB();
       $pdo = $db->getPDO();
       $q = $pdo->prepare($sql);

--- a/class/Resource/ShowResource.php
+++ b/class/Resource/ShowResource.php
@@ -22,12 +22,6 @@ class ShowResource extends BaseAbstract
 {
 
     /**
-    * Unique id that is associated with the show
-    * @var \phpws2\Variable\IntegerVar
-    */
-    protected $showId;
-
-    /**
      * Title of show
      * @var \phpws2\Variable\StringVar
      */
@@ -51,7 +45,6 @@ class ShowResource extends BaseAbstract
     public function __construct()
     {
         parent::__construct();
-        $this->showId = new \phpws2\Variable\IntegerVar(1, 'showId');
         $this->title = new \phpws2\Variable\StringVar(null, 'title');
         $this->title->setLimit('255');
         $this->active = new \phpws2\Variable\BooleanVar(0, 'active');

--- a/class/View/ShowView.php
+++ b/class/View/ShowView.php
@@ -19,7 +19,8 @@
 
    public function show()
    {
-     $this->createShowButton();
+     // Removed this until fixed or implemented or deleted..idk
+     //$this->createShowButton();
      return $this->scriptView('shows');
    }
 

--- a/exports.js
+++ b/exports.js
@@ -4,8 +4,8 @@ exports.APP_DIR = exports.path.resolve(__dirname, 'javascript')
 exports.entry = {
   vendor: ['react', 'react-dom'],
 
-  shows: exports.APP_DIR + '/show/index.jsx',
-  edit: exports.APP_DIR + '/edit/index.jsx',
+  shows: exports.APP_DIR + '/Show/index.jsx',
+  edit: exports.APP_DIR + '/Edit/index.jsx',
   /*SlideEdit: exports.APP_DIR + '/Slide/edit.jsx',
   Present: exports.APP_DIR + '/Show/Present.jsx',
   ShowView: exports.APP_DIR + 'Show/ShowView.jsx',

--- a/javascript/Edit/Edit.jsx
+++ b/javascript/Edit/Edit.jsx
@@ -36,8 +36,6 @@ export default class Edit extends Component {
   }
 
   save() {
-    // Do something with content where we can save it as json to the db
-    console.log("--- Saving ---")
     let copy = [...this.state.content]
     // Save/update a new js resource
     let r = this.state.resource
@@ -46,17 +44,13 @@ export default class Edit extends Component {
       content: copy,
       resource: r
     })
-    console.log("*** Contetnt saved locally ***")
-    // Issue being caused when loading data!!!
-    //let stringContent = JSON.stringify(this.state.content)
-    //console.log(JSON.parse(stringContent))
+
     $.ajax({
       url: './slideshow/Show/' + this.state.id,
-      data: {content: this.state.content/*stringContent*/, resource: this.state.resource},
+      data: {content: this.state.content, resource: this.state.resource},
       type: 'put',
       dataType: 'json',
       success: function() {
-        console.log("*** Contetnt saved remotely ***")
         this.load();
       }.bind(this),
       error: function(req, err) {
@@ -73,14 +67,9 @@ export default class Edit extends Component {
       type: 'GET',
       dataType: 'json',
       success: function(data) {
-        console.log("pre JSON conversion:")
-        //let quotes = data['slides'].replace(/"/g,'\'')
-        console.log(data['slides'])
-        //let loaded = JSON.parse(data['slides'])
+
         let loaded = data['slides']
-        //loaded.saveContent = JSON.parse(loaded.saveContent);
-        console.log("post JSON conversion: ")
-        console.log(loaded)
+
         if (loaded[this.state.currentSlide] != undefined) {
           this.setState({
             content: loaded,
@@ -89,7 +78,7 @@ export default class Edit extends Component {
         }
       }.bind(this),
       error: function(req, err) {
-                //alert("Failed to grab data.")
+        alert("Failed to load data.")
         console.error(req, err.toString());
       }.bind(this)
     });
@@ -199,13 +188,8 @@ export default class Edit extends Component {
   }
 
   saveContentState(saveContent, stackNum) {
-    /*console.log("current stack:");
-    console.log(this.state.content[this.state.currentSlide].stack[0].saveContent)
-    console.log("saveContent passed:");
-    console.log(saveContent)*/
+    // Updates the saveContent variable within the slideshow stack.
     this.state.content[this.state.currentSlide].stack[stackNum].saveContent = saveContent
-    console.log(this.state.content[this.state.currentSlide].stack[stackNum].saveContent)
-    //this.state.content[this.state.currentSlide].stack.saveContent = saveContent
   }
 
   render() {

--- a/javascript/Edit/Edit.jsx
+++ b/javascript/Edit/Edit.jsx
@@ -10,7 +10,8 @@ export default class Edit extends Component {
     super()
 
     this.state = {
-      id: 1,
+      // There are some wierd bugs with this and it's not really neccesary to have.
+      // id: sessionStorage.getItem('id'),
       currentSlide: 0,
       // data that represents the slideshow:
       resource: Show,
@@ -46,7 +47,7 @@ export default class Edit extends Component {
     })
 
     $.ajax({
-      url: './slideshow/Show/' + this.state.id,
+      url: './slideshow/Show/' + window.sessionStorage.getItem('id'),
       data: {content: this.state.content, resource: this.state.resource},
       type: 'put',
       dataType: 'json',
@@ -54,7 +55,7 @@ export default class Edit extends Component {
         this.load();
       }.bind(this),
       error: function(req, err) {
-        alert("Failed to save.")
+        alert("Failed to save show " + window.sessionStorage.getItem('id'))
         console.error(req, err.toString());
       }.bind(this)
     });
@@ -63,10 +64,10 @@ export default class Edit extends Component {
   load() {
     // This will retrieve content and load it into the state through ajax/REST.
     $.ajax({
-      url: './slideshow/Show/edit/?id=' + this.state.id,
+      url: './slideshow/Show/edit/?id=' + window.sessionStorage.getItem('id'),
       type: 'GET',
       dataType: 'json',
-      success: function(data) {
+      success: function (data) {
 
         let loaded = data['slides']
 

--- a/javascript/Edit/Edit.jsx
+++ b/javascript/Edit/Edit.jsx
@@ -11,11 +11,7 @@ export default class Edit extends Component {
 
     this.state = {
       id: 1,
-<<<<<<< HEAD
-      currentSlide: 1,
-=======
       currentSlide: 0,
->>>>>>> backMerge
       // data that represents the slideshow:
       resource: Show,
       content: [

--- a/javascript/Edit/EditView.jsx
+++ b/javascript/Edit/EditView.jsx
@@ -72,8 +72,6 @@ export default class EditView extends Component {
 
   render() {
     // Lazy with creating name.
-    console.log("EditView:")
-    console.log(this.props.content)
     let data = this.props.content.map(function(content) {
       // lol, the key is ridiculous, but it works!
       // Needs to be unique for a given slide AND unique between all slides

--- a/javascript/Edit/Workspace.jsx
+++ b/javascript/Edit/Workspace.jsx
@@ -47,9 +47,6 @@ export default class Workspace extends Component {
   }
 
   componentDidMount() {
-    console.log("componentDidMount:")
-    console.log(this.props.content)
-    //console.log(ContentState.createFromBlockArray(this.props.content.saveContent[0], this.props.content.saveContent[1]));
     if (this.props.content != null || this.props.content != undefined) {
       this.loadEditorState(this.props.content)
     }
@@ -57,21 +54,16 @@ export default class Workspace extends Component {
 
   componentDidUpdate(prevProps) {
     if (this.props.content != undefined) {
-      console.log("componentDidUpdate:")
-      console.log(this.props.content)
-      console.log(prevProps.content)
       this.saveEditorState()
       if (prevProps.content != this.props.content || prevProps.currentSlide !== this.props.currentSlide) {
-        this.saveEditorState()
         this.loadEditorState(this.props.content)
       }
     }
   }
 
   loadEditorState(content) {
-    console.log("loadEditorState:")
+    // If there isn't any content then we make some
     if (content.saveContent === undefined || content.saveContent == null) {
-      console.log("New workspace has been made.")
       let body = ""
       switch (content.type) {
         case 'Title':
@@ -89,17 +81,14 @@ export default class Workspace extends Component {
         default:
           body = "Insert text here."
       }
+
       this.setState({
          editorState: createEditorStateWithText(body)
        })
+
        this.saveEditorState()
     } else {
-      console.log("saveContent from loadEditorState:")
-      console.log(content.saveContent)
-      /*
-      let contentState = ContentState.createFromBlockArray(
-                          JSON.parse(content.saveContent[0]),
-                          JSON.parse(content.saveContent[1]));*/
+
       let contentState = convertFromRaw(JSON.parse(content.saveContent))
 
       this.setState({
@@ -109,23 +98,10 @@ export default class Workspace extends Component {
   }
 
   saveEditorState() {
-
     if (this.state.editorState != undefined) {
       // See draft.js documentation to understand what these are:
-      /*
-      This way of saving using block maps but im getting an error so I must go back to raw content states.
-      let contentState = this.state.editorState.getCurrentContent()
-      const blockMap = contentState.getBlockMap();
-      const entityMap = contentState.getEntityMap();
-
-      const saveContent = [JSON.stringify(blockMap), JSON.stringify(entityMap)];
-      */
-      console.log("saveEditorState:")
-
       let contentState = this.state.editorState.getCurrentContent()
       let saveContent = JSON.stringify(convertToRaw(contentState))
-      console.log("saveContent from saveEditorState:")
-      console.log(saveContent)
 
       this.props.saveContentState(saveContent, this.props.content.id - 1)
     }
@@ -144,7 +120,6 @@ export default class Workspace extends Component {
     if (command === 'save') {
       // perform a save whether this may be a function call or something idk.
       this.saveEditorState()
-      alert("content saved!")
       return 'handled'
     }
     return 'not-handled'

--- a/javascript/Show/ShowCard.jsx
+++ b/javascript/Show/ShowCard.jsx
@@ -95,14 +95,15 @@ export default class ShowCard extends Component {
    // Pass showId to edit page. So far all shows point to the same edit page.
    $.ajax({
      method: 'GET',
-     url: './slideshow/Show/Edit/' + this.state.id,
+     url: './slideshow/Show/Edit/',
      data: { id: this.state.id },
      error: function(req, err) {
        alert("Failed to load show.")
        console.error(req, err.toString())
      }.bind(this)
    })
-   window.location.href = './slideshow/Show/Edit'
+   window.sessionStorage.setItem('id', this.state.id)
+   window.location.href = './slideshow/Show/Edit/?id=' + this.state.id
  }
 
   render() {

--- a/javascript/Show/ShowView.jsx
+++ b/javascript/Show/ShowView.jsx
@@ -34,9 +34,9 @@ export default class ShowView extends Component {
         type: 'post',
         dataType: 'json',
         success: function() {
-          // Pass show id through to this.
-          window.location.href = './slideshow/Show/edit'
-          
+          // TODO: eventually I would like this to redirect to edit rather than alert.
+          this.switchModal()
+          this.getData()
         }.bind(this),
         error: function(req, err) {
           alert("Failed to save data.")

--- a/javascript/Show/ShowView.jsx
+++ b/javascript/Show/ShowView.jsx
@@ -34,12 +34,9 @@ export default class ShowView extends Component {
         type: 'post',
         dataType: 'json',
         success: function() {
-          // Pass showId through to this.
-          // We probs need to create a showId right here
-          // There's a better way to do this :/
-          // I need to thik this one out mang.
-          //window.location.href = './slideshow/Show/edit'
-          //console.log(this.state.resource);
+          // Pass show id through to this.
+          window.location.href = './slideshow/Show/edit'
+          
         }.bind(this),
         error: function(req, err) {
           alert("Failed to save data.")


### PR DESCRIPTION
Okay so this issues #32, #33, #34, & #41  was really fun and tortuous to complete.
# How it works
* When the workspace prop is updated, a save method will extract the _local save data_ from the editorState by extracting the contentState and converting that to a raw object that is then converted into a json string.
* Then, when the save button is clicked an ajax request (PUT) is completed, sending the _local save data_ to the database corresponding to the id that is stored in the state (within Edit.jsx).
* On load, an ajax request (GET) is completed returning just the _local save data_ and storing it into the state under the content array/stack
* A load will occur when the workspace component is mounted or updated.
* The way a unique edit works is when someone clicks edit on a ShowCard, the id is passed into the session and from the edit paged that id is loaded and used in the ajax request that loads the content.
# Problems / Where to Go from Here
* ~~I hard coded the id that is passed to edit, meaning we can only save and load on the first show.~~
    * But, this is an easy fix as we need to just add to the controller where we pass an id to the editHtmlCommand
    * I figured this is a separate issue and should be resolved on its own.
* ~~Autosaving?~~ Nah 
    * In order to save one has to click the button in the NavBar
* ctr-s doesn't work in the way it should
    * I didn't bother fixing this because we will need to go through individual key commands (ctr-z, etc) when the [toolbar](#25 ) is complete because it coincides with key commands.
