### PR TITLE
Added support for plugins. Added undo, redo buttons to toolbar.

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -72,9 +72,6 @@ class Module extends \Canopy\Module implements \Canopy\SettingDefaults
 
     public function runTime(Request $request)
     {
-        if (\Current_User::allow('slideshow')) {
-            NavBar::addItem($this->showList());
-        }
         if ($request->getModule() !== 'slideshow') {
             \Layout::addStyle('slideshow');
             $this->showNavBar($request);
@@ -90,10 +87,6 @@ class Module extends \Canopy\Module implements \Canopy\SettingDefaults
         }
     }
 
-    private function showList()
-    {
-        return '<a class="btn btn-primary" href="./slideshow/Show/list"><i class="fas fa-list"></i> Show list</a>';
-    }
 
     public static function autoloader($class_name)
     {

--- a/javascript/Edit/CustomToolbarButtons.jsx
+++ b/javascript/Edit/CustomToolbarButtons.jsx
@@ -1,0 +1,24 @@
+'use strict'
+import React, { Component } from 'react'
+import './buttonStyle.css'
+
+import { EditorState, AtomicBlckUtils} from 'draft-js'
+
+export default class CustomToolbarButtons extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  insertImage() {
+    console.log(this.props)
+    alert("Insert Image:\n\nnot yet implemented")
+  }
+
+  render() {
+    return (
+      <span>
+        <button className="toolbar" onClick={this.insertImage.bind(this)}><i className="fas fa-images"></i></button>
+      </span>
+    )
+  }
+}

--- a/javascript/Edit/EditView.jsx
+++ b/javascript/Edit/EditView.jsx
@@ -2,9 +2,10 @@
 import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 
-import Editor, { createEditorStateWithText, createWithContent } from 'draft-js-plugins-editor'
+import Editor, { createEditorStateWithText, createWithContent, composeDecorators } from 'draft-js-plugins-editor'
 import {EditorState, ContentState, getDefaultKeyBinding, RichUtils, KeyBindingUtil, convertToRaw, convertFromRaw} from 'draft-js'
 
+// Toolbar imports
 import {
   ItalicButton,
   BoldButton,
@@ -15,15 +16,29 @@ import {
   HeadlineThreeButton,
   UnorderedListButton,
   OrderedListButton,
-  BlockquoteButton,
-  CodeBlockButton
 } from 'draft-js-buttons'
+
+import CustomButtons from './CustomToolbarButtons.jsx'
+import UndoRedo from './UndoRedoButtons.jsx'
 
 import createToolbarPlugin, { Separator } from 'draft-js-static-toolbar-plugin'
 import 'draft-js-static-toolbar-plugin/lib/plugin.css'
 
+// Imports for images
+import createImagePlugin from 'draft-js-image-plugin'
+import createResizeablePlugin from 'draft-js-resizeable-plugin'
+import createAlignmentPlugin from 'draft-js-alignment-plugin'
+import createFocusPlugin from 'draft-js-focus-plugin';
+
+const alignmentPlugin = createAlignmentPlugin()
+const { AlignmentTool } = alignmentPlugin
+const resizeablePlugin = createResizeablePlugin()
+const focusPlugin = createFocusPlugin();
+
 const staticToolbar = createToolbarPlugin({
   structure: [
+    UndoRedo,
+    Separator,
     BoldButton,
     ItalicButton,
     UnderlineButton,
@@ -34,16 +49,27 @@ const staticToolbar = createToolbarPlugin({
     HeadlineThreeButton,
     UnorderedListButton,
     OrderedListButton,
-    BlockquoteButton,
-    CodeBlockButton,
+    Separator,
+    CustomButtons
   ]
 })
 
+const decorator = composeDecorators(
+  resizeablePlugin.decorator,
+  alignmentPlugin.decorator,
+  focusPlugin.decorator,
+)
+
+const imagePlugin = createImagePlugin({ decorator })
 
 const { Toolbar } = staticToolbar
 
 const plugins = [
   staticToolbar,
+  focusPlugin,
+  alignmentPlugin,
+  resizeablePlugin,
+  imagePlugin
 ]
 
 export default class EditView extends Component {
@@ -66,7 +92,7 @@ export default class EditView extends Component {
   componentDidMount() {
     this.loadEditorState()
   }
-
+CustomToolbar
   componentDidUpdate(prevProps) {
     // This catches the load from the db, which is slower than React's render which is why it's in componentDidUpdate.
     // and when a slide (props) is changed.
@@ -107,18 +133,6 @@ export default class EditView extends Component {
     }
   }
 
-  _undo()
-  {
-    // This is here but it is not yet implemented
-    // I will add this to a button on the nav bar at some point
-    this.onEditChange(EditorState.undo(EditorState))
-  }
-
-  _redo()
-  {
-    this.onEditChange(EditorState.redo(EditorState))
-  }
-
   render() {
 
     var editorStyle = {
@@ -143,6 +157,7 @@ export default class EditView extends Component {
               onFocus={() => this.setState({ hasFocus: true })}
               onBlur={() => this.setState({ hasFocus: false })}
               ref={(element) => { this.editor = element; }} />
+
           </div>
         </div>
       </div>

--- a/javascript/Edit/NavBar.jsx
+++ b/javascript/Edit/NavBar.jsx
@@ -29,6 +29,7 @@ export default class NavBar extends Component {
       renameVal: ""
     }
 
+    this.returnToShowList = this.returnToShowList.bind(this)
     this.toggleFile = this.toggleFile.bind(this)
     this.toggleEdit = this.toggleEdit.bind(this)
     this.toggleInsert = this.toggleInsert.bind(this)
@@ -38,6 +39,11 @@ export default class NavBar extends Component {
     this.renameCurrentSlide = this.renameCurrentSlide.bind(this)
     this.handlePresent = this.handlePresent.bind(this)
     this.handleImage = this.handleImage.bind(this)
+  }
+
+  returnToShowList() {
+    this.props.save()
+    window.location.href = './slideshow/Show/list'
   }
 
   toggleFile() {
@@ -121,6 +127,7 @@ export default class NavBar extends Component {
     return (
       <div>
       <ButtonGroup>
+        <Button onClick={this.returnToShowList} color="primary"><i className="fas fa-arrow-circle-left"></i> Show List</Button>
         <ButtonDropdown isOpen={this.state.fileOpen} toggle={this.toggleFile}>
           <DropdownToggle caret>
             File

--- a/javascript/Edit/NavBar.jsx
+++ b/javascript/Edit/NavBar.jsx
@@ -25,6 +25,7 @@ export default class NavBar extends Component {
       editOpen: false,
       insertOpen: false,
       renameOpen: false,
+      imageOpen: false,
       renameVal: ""
     }
 
@@ -32,9 +33,11 @@ export default class NavBar extends Component {
     this.toggleEdit = this.toggleEdit.bind(this)
     this.toggleInsert = this.toggleInsert.bind(this)
     this.toggleRename = this.toggleRename.bind(this)
+    this.toggleImage = this.toggleImage.bind(this)
     this.handleRename = this.handleRename.bind(this)
     this.renameCurrentSlide = this.renameCurrentSlide.bind(this)
     this.handlePresent = this.handlePresent.bind(this)
+    this.handleImage = this.handleImage.bind(this)
   }
 
   toggleFile() {
@@ -61,9 +64,21 @@ export default class NavBar extends Component {
     })
   }
 
+  toggleImage() {
+    this.setState({
+      imageOpen: !this.state.imageOpen
+    })
+  }
+
   handleRename(event) {
     this.setState({
       renameVal: event.target.value
+    })
+  }
+
+  handleImage(event) {
+    this.setState({
+      imageUrl: event.target.value
     })
   }
 
@@ -82,24 +97,26 @@ export default class NavBar extends Component {
     window.location.href = './slideshow/Show/Present/?id=' + this.props.id
   }
 
+
   render() {
-    const modal = (
-      <Modal isOpen={this.state.renameOpen} toggle={this.toggleRename} fade={false} backdrop={true}>
-        <ModalHeader toggle={this.toggleRename}>Rename Slide Title:</ModalHeader>
+    const imageModal = (
+      <Modal isOpen={this.state.imageOpen} toggle={this.toggleImage} fade={false} backdrop={true}>
+        <ModalHeader toggle={this.toggleImage}>Enter Image Url</ModalHeader>
         <ModalBody>
           <InputGroup>
             <Input
                     type="text"
-                    placeholder="Rename Slide"
-                    onChange={this.handleRename}
-                    value={this.state.renameVal} />
+                    placeholder="Image Url"
+                    onChange={this.handleImage}
+                    value={this.state.imageUrl} />
               <InputGroupAddon addonType="append">
-            <Button onClick={this.renameCurrentSlide.bind(this, this.state.renameVal)} color="success">Save</Button>
+            <Button onClick={this.toggleImage} color="primary">Submit</Button>
             </InputGroupAddon>
           </InputGroup>
         </ModalBody>
       </Modal>
     )
+
 
     return (
       <div>
@@ -127,14 +144,14 @@ export default class NavBar extends Component {
             Insert
           </DropdownToggle>
           <DropdownMenu>
-            <DropdownItem value="Image">Image</DropdownItem>
+            <DropdownItem value="Image" onClick={this.toggleImage}>Image</DropdownItem>
             <DropdownItem value="Quiz">Quiz</DropdownItem>
             <DropdownItem divider />
             <DropdownItem onClick={this.props.insertSlide}>New Slide</DropdownItem>
           </DropdownMenu>
         </ButtonDropdown>
       </ButtonGroup>
-      {modal}
+      {imageModal}
     </div>
     )
   }

--- a/javascript/Edit/UndoRedoButtons.jsx
+++ b/javascript/Edit/UndoRedoButtons.jsx
@@ -1,0 +1,28 @@
+'use strict'
+import React, { Component } from 'react'
+import './buttonStyle.css'
+
+import { EditorState, AtomicBlckUtils} from 'draft-js'
+
+export default class UndoRedoButtons extends Component {
+  constructor(props) {
+    super(props)
+  }
+
+  _undo() {
+    this.props.setEditorState(EditorState.undo(this.props.getEditorState()))
+  }
+
+  _redo() {
+    this.props.setEditorState(EditorState.redo(this.props.getEditorState()))
+  }
+
+  render() {
+    return (
+      <span>
+        <button className="toolbar" onClick={this._undo.bind(this)}><i className="fas fa-undo"></i></button>
+        <button className="toolbar" onClick={this._redo.bind(this)}><i className="fas fa-redo"></i></button>
+      </span>
+    )
+  }
+}

--- a/javascript/Edit/buttonStyle.css
+++ b/javascript/Edit/buttonStyle.css
@@ -1,0 +1,15 @@
+
+button.toolbar {
+  background: #fbfbfb;
+  color: #888;
+  font-size: 18px;
+  border: 0;
+  padding-top: 5px;
+  vertical-align: bottom;
+  height: 34px;
+  width: 36px;
+}
+
+i {
+  fill: #888;
+}

--- a/package.json
+++ b/package.json
@@ -6,9 +6,12 @@
   "dependencies": {
     "canopy-react-buttongroup": "^0.1.4",
     "draft-js": "^0.10.5",
+    "draft-js-alignment-plugin": "^2.0.5",
     "draft-js-buttons": "^2.0.1",
-    "draft-js-image-plugin": "^2.0.5",
+    "draft-js-focus-plugin": "^2.2.0",
+    "draft-js-image-plugin": "^2.0.6",
     "draft-js-plugins-editor": "^2.1.1",
+    "draft-js-resizeable-plugin": "^2.0.8",
     "draft-js-static-toolbar-plugin": "^2.0.2",
     "draft.js": "^0.2.0",
     "last-draft-js-plugins": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "bootstrap": "^4.1.3",
-    "browser-sync": "^2.24.6",
+    "browser-sync": "^2.26.3",
     "browser-sync-webpack-plugin": "^2.0.1",
     "css-loader": "^0.28.11",
     "es6-promise": "^4.2.4",


### PR DESCRIPTION
#55 
I added support for some draft.js plugins, however I have yet to fully implement them. I believe that we need to handle images differently than urls, meaning that this will become a different issue, handled by the back end and/or Canopy. So, I just added support for rendering it on the front end. This support code doesn't do much right now, but once we can handle the saving of the images on the back end, we can implement what I have added. I also added support for the addition of new buttons to the toolbar, such as a style sheet and a new jsx component, in which we can add features to as we move ahead with this project. Finally, using the previously mentioned toolbar support, I added functioning undo and redo buttons. 