### PR TITLE
Session Handling and User Roles 🙂

### DIFF
--- a/boost/Tables.php
+++ b/boost/Tables.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * MIT License
+ * Copyright (c) 2019 Electronic Student Services @ Appalachian State University
+ *
+ * See LICENSE file in root directory for copyright and distribution permissions.
+ *
+ * @author Matthew McNaney <mcnaneym@appstate.edu>
+ * @author Tyler Craig <craigta1@appstate.edu>
+ * @license https://opensource.org/licenses/MIT
+ */
+namespace slideshow;
+
+use phpws2\Database;
+
+class Tables
+{
+
+    protected $db;
+
+    public function __construct()
+    {
+        $this->db = Database::getDB();
+    }
+
+    public function createShow()
+    {
+        $show = new \slideshow\Resource\ShowResource;
+        return $show->createTable($this->db);
+    }
+
+    public function createSession()
+    {
+        $session = new \slideshow\Resource\SessionResource;
+        return $session->createTable($this->db);
+    }
+}

--- a/boost/boost.php
+++ b/boost/boost.php
@@ -18,7 +18,7 @@
  * @license http://opensource.org/licenses/gpl-3.0.html
  */
 $proper_name = 'Slideshow';
-$version = '1.1.0';
+$version = '1.2.0';
 $register = false;
 $unregister = false;
 $import_sql = false;

--- a/boost/install.php
+++ b/boost/install.php
@@ -2,29 +2,32 @@
 
 /**
  * @author Matthew McNaney <mcnaneym at appstate dot edu>
+ * @author Tyler Craig <craigta1 at appstate dot edu>
  */
+
+use phpws2\Database;
+require_once PHPWS_SOURCE_DIR . 'mod/slideshow/boost/Tables.php';
+
 function slideshow_install(&$content)
 {
     $db = \phpws2\Database::getDB();
     $db->begin();
 
+    $show;
+    $session;
     try {
-        /* TODO: Add install commands for our tables using Canopy functions. */
+        $tables = new slideshow\Tables;
 
-
-        $show = new \slideshow\Resource\ShowResource;
-        $show->createTable($db);
-
-        $slide = new \slideshow\Resource\SlideResource;
-        $slide->createTable($db);
+        $show = $tables->createShow();
+        $session = $tables->createSession();
 
     } catch (\Exception $e) {
         \phpws2\Error::log($e);
-        $backout = array_reverse($tables);
-        foreach ($backout as $tbl) {
-            $tbl->drop();
-        }
         $db->rollback();
+
+        $show->drop(true);
+        $session->drop(true);
+
         throw $e;
     }
     $db->commit();

--- a/boost/uninstall.php
+++ b/boost/uninstall.php
@@ -25,14 +25,14 @@ function slideshow_uninstall(&$content)
     $db->begin();
     try {
       $db->buildTable('ss_show')->drop();
-      $db->buildTable('ss_slide')->drop();
+      $db->buildTable('ss_session')->drop();
     }
     catch (Exception $e) {
       \phpws2\Error::log($e);
       throw $e;
     }
     $db->commit();
-    
+
     $content[] = "Tables dropped";
     return true;
 

--- a/boost/update.php
+++ b/boost/update.php
@@ -26,6 +26,8 @@ class slideshowUpdate
     switch (1) {
       case $this->compare('1.1.0'):
         $this->update('1.1.0');
+      case $this->compare('1.2.0'):
+        $this->update('1.2.0');
     }
   }
 
@@ -51,6 +53,17 @@ class slideshowUpdate
     $changes[] = 'content now saves to the database';
     $changes[] = 'content can now be loaded from the database';
     $this->addContent('1.1.0', $changes);
+  }
+
+  private function v1_2_0()
+  {
+      $db = \phpws2\Database::getDB();
+
+      $session = new \slideshow\Resource\SessionResource;
+      $session->createTable($db);
+
+      $changes[] = 'can now keep track of user progress through the quizzes they take';
+      $this->addContent('1.2.0', $changes);
   }
 
   private function addContent($version, array $changes)

--- a/class/Controller/Session/Admin.php
+++ b/class/Controller/Session/Admin.php
@@ -11,44 +11,37 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * @author Matthew McNaney <mcnaney at gmail dot com>
+ * @author Tyler Craig <craigta1 at appstate dot edu>
  *
  * @license http://opensource.org/licenses/lgpl-3.0.html
  */
 
-namespace slideshow\Controller\Show;
+namespace slideshow\Controller\Session;
 
 use Canopy\Request;
-use slideshow\Factory\ShowFactory as Factory;
-use slideshow\View\ShowView as View;
-use slideshow\Controller\RoleController;
+use slideshow\Factory\SessionFactory;
 
-class Base extends RoleController
+class Admin extends Base
 {
-
     /**
-     * @var slideshow\Factory\ShowFactory
+     * @var slideshow\Factory\SessionFactory
      */
     protected $factory;
 
-    /**
-     * @var slideshow\View\ShowView
-     */
-    protected $view;
-
-    protected function loadFactory()
+    /*
+    * This does nothing because if we are an admin we are demoing the show
+    */
+    protected function putCommand($request)
     {
-        $this->factory = new Factory;
+        return true;
     }
 
-    protected function loadView()
+    /*
+    * This does nothing because if we are an admin we are demoing the show
+    */
+    protected function getCommand($request)
     {
-        $this->view = new View;
-    }
-
-    protected function viewHtmlCommand(Request $request)
-    {
-        return 'Show.Base::viewHtmlCommand';
+        return true;
     }
 
 }

--- a/class/Controller/Session/Base.php
+++ b/class/Controller/Session/Base.php
@@ -16,9 +16,28 @@
  * @license http://opensource.org/licenses/lgpl-3.0.html
  */
 
-namespace slideshow\Controller\Show;
+namespace slideshow\Controller\Session;
 
-class User extends Logged
+use Canopy\Request;
+use slideshow\Factory\SessionFactory as Factory;
+use slideshow\Controller\RoleController;
+
+class Base extends RoleController
 {
+
+    /**
+     * @var slideshow\Factory\SessionFactory
+     */
+    protected $factory;
+
+    protected function loadFactory()
+    {
+        $this->factory = new Factory;
+    }
+
+    protected function loadView()
+    {
+
+    }
 
 }

--- a/class/Controller/Session/Logged.php
+++ b/class/Controller/Session/Logged.php
@@ -11,14 +11,32 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * @author Matthew McNaney <mcnaney at gmail dot com>
+ * @author Tyler Craig <craigta1 at appstate dot edu>
  *
  * @license http://opensource.org/licenses/lgpl-3.0.html
  */
 
-namespace slideshow\Controller\Show;
+namespace slideshow\Controller\Session;
 
-class User extends Logged
+use Canopy\Request;
+use slideshow\Factory\SessionFactory;
+
+class Logged extends Base
 {
+    /**
+     * @var slideshow\Factory\SessionFactory
+     */
+    protected $factory;
+
+    protected function putCommand($request)
+    {
+        $this->factory->put($request);
+        return true;
+    }
+
+    protected function viewJsonCommand($request)
+    {
+        return $this->factory->get($request);
+    }
 
 }

--- a/class/Controller/Show/Admin.php
+++ b/class/Controller/Show/Admin.php
@@ -48,7 +48,7 @@ class Admin extends Base
     */
     protected function listHtmlCommand(Request $request)
     {
-        return $this->view->show();
+        return $this->view->adminShow();
     }
 
     /**

--- a/class/Controller/Show/Logged.php
+++ b/class/Controller/Show/Logged.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * See docs/AUTHORS and docs/COPYRIGHT for relevant info.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @author Matthew McNaney <mcnaney at gmail dot com>
+ *
+ * @license http://opensource.org/licenses/lgpl-3.0.html
+ */
+
+namespace slideshow\Controller\Show;
+
+use Canopy\Request;
+use slideshow\Factory\ShowFactory;
+use slideshow\View\ShowView;
+
+class Logged extends Base
+{
+  /**
+   * @var slideshow\Factory\ShowFactory
+   */
+  protected $factory;
+
+  /**
+  * @var slideshow\View\ShowView
+  */
+  protected $view;
+
+  /**
+  * Handles the request to render the list page.
+  */
+  protected function listHtmlCommand(Request $request)
+  {
+      return $this->view->show();
+  }
+
+  protected function listJsonCommand(Request $request)
+  {
+      return array('listing'=>$this->factory->listing(true));
+  }
+
+  /**
+  * Handles the request to render the present page.
+  */
+  protected function presentHtmlCommand(Request $request)
+  {
+    return $this->view->present();
+  }
+
+}

--- a/class/Controller/Show/Logged.php
+++ b/class/Controller/Show/Logged.php
@@ -55,4 +55,14 @@ class Logged extends Base
     return $this->view->present();
   }
 
+  protected function presentJsonCommand(Request $request)
+  {
+    $vars = $request->getRequestVars();
+    $id = $vars['id'];
+    return array(
+      'slides' => $this->factory->getSlides($id),
+      'title' => $this->factory->getShowName($id)
+    );
+  }
+
 }

--- a/class/Factory/SessionFactory.php
+++ b/class/Factory/SessionFactory.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * See docs/AUTHORS and docs/COPYRIGHT for relevant info.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @author Tyler Craig <craigta1 at appstate dot edu>
+ *
+ * @license http://opensource.org/licenses/lgpl-3.0.html
+ */
+
+namespace slideshow\Factory;
+
+use slideshow\Resource\SessionResource as Resource;
+use phpws2\Database;
+use Canopy\Request;
+
+class SessionFactory extends Base
+{
+
+    protected function build()
+    {
+        return new Resource;
+    }
+
+    protected function post(Request $request, $showId)
+    {
+        $resource = $this->build();
+
+        $resource->highestSlide = 0;
+        $resource->completed = false;
+        $resource->showId = $showId;
+
+        $this->saveResource($resource, 'ss_session');
+
+        return $resource;
+    }
+
+    public function get(Request $request)
+    {
+        $vars = $request->getRequestVars();
+        $showId = intval($vars['Session']);
+        $userId = \Current_User::getId();
+
+        $sql = "SELECT id, highestSlide, completed FROM ss_session WHERE userId=:userId AND showId=:showId;";
+        $db = Database::getDB();
+        $pdo = $db->getPDO();
+        $q = $pdo->prepare($sql);
+        $q->execute(array(':userId' => $userId, ':showId' => $showId));
+        $result = $q->fetch();
+        //var_dump($result);
+        if (empty($result)) {
+            $this->post($request, $showId);
+            $this->get($request);
+        }
+        return array('highestSlide' => $result[1], 'completed' => $result[2]);
+    }
+
+    public function put(Request $request)
+    {
+        $vars = $request->getRequestVars();
+        $showId = intval($vars['Session']);
+        $userId = \Current_User::getId();
+
+        $sql = "SELECT id, highestSlide, completed FROM ss_session WHERE userId=:userId AND showId=:showId;";
+        $db = Database::getDB();
+        $pdo = $db->getPDO();
+        $q = $pdo->prepare($sql);
+        $q->execute(array(':userId' => $userId, ':showId' => $showId));
+        $result = $q->fetch();
+        if (empty($result)) {
+            return $this->post($request, $showId);
+        }
+
+        // Builds resource based on the corresponding slideshow id and user id
+        $resource = $this->load($result['id']);
+
+
+        $highestSlide = $request->pullPutVarIfSet('highestSlide');
+        $completed = $request->pullPutVarIfSet('completed') === 'true' ? true : false;
+
+        $resource->highestSlide = $highestSlide;
+        if (!$resource->completed && $completed) {
+            $resource->completed = $completed;
+        }
+        $this->saveResource($resource);
+        return $resource;
+    }
+
+}

--- a/class/Resource/SessionResource.php
+++ b/class/Resource/SessionResource.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * See docs/AUTHORS and docs/COPYRIGHT for relevant info.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @author Tyler Craig <craigta1 at appstate dot edu>
+ *
+ * @license http://opensource.org/licenses/lgpl-3.0.html
+ */
+
+namespace slideshow\Resource;
+
+class SessionResource extends BaseAbstract
+{
+    /**
+    * User id
+    * @var phpws2\Variable\IntegerVar
+    */
+    protected $userId;
+
+    /**
+    * SlideShow id
+    * @var phpws2\Variable\IntegerVar
+    */
+    protected $showId;
+
+    /**
+    * Users highest slide completed
+    * @var phpws2\Variable\SmallInteger
+    */
+    protected $highestSlide;
+
+    /**
+    * True if user has completed the slideshow
+    * @var phpws2\Variable\BooleanVar
+    */
+    protected $completed;
+
+    protected $table = 'ss_session';
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->userId = new\phpws2\Variable\IntegerVar(\Current_User::getId(), 'userId');
+        $this->showId = new \phpws2\Variable\IntegerVar(0, 'showId');
+        $this->highestSlide = new \phpws2\Variable\SmallInteger(0, 'highestSlide');
+        $this->completed = new \phpws2\Variable\BooleanVar(false, 'completed');
+    }
+
+}

--- a/class/View/ShowView.php
+++ b/class/View/ShowView.php
@@ -19,6 +19,11 @@
 
    public function show()
    {
+       return $this->scriptView('view');
+   }
+
+   public function adminShow()
+   {
      // Removed this until fixed or implemented or deleted..idk
      //$this->createShowButton();
      return $this->scriptView('shows');

--- a/exports.js
+++ b/exports.js
@@ -7,4 +7,5 @@ exports.entry = {
   shows: exports.APP_DIR + '/Show/index.jsx',
   edit: exports.APP_DIR + '/Edit/index.jsx',
   present: exports.APP_DIR + '/Present/index.jsx',
+  view: exports.APP_DIR + '/View/index.jsx'
 }

--- a/javascript/Present/Present.jsx
+++ b/javascript/Present/Present.jsx
@@ -25,6 +25,7 @@ export default class Present extends Component {
       finishFlag: false // true when user has completed the show
     }
     this.load = this.load.bind(this)
+    this.updateSession = this.updateSession.bind(this)
 
     this.prev = this._prev.bind(this)
     this.next = this._next.bind(this)
@@ -36,6 +37,7 @@ export default class Present extends Component {
 
   componentDidMount() {
     this.load()
+    this.loadSession()
   }
 
   componentDidUpdate() {
@@ -44,7 +46,7 @@ export default class Present extends Component {
       this.setState({
         quizNextFlag: false,
         nextDisable: false,
-        quizPassed: false
+        quizPassed: false,
       })
     }
     else if (this.state.nextFlag) {
@@ -53,6 +55,7 @@ export default class Present extends Component {
       // However, it works!!! Imma try my best to comment an explination for how this works - Tyler
 
       // slide has changed
+      this.updateSession()
       this.setState({nextDisable: true, prevDisable: true})
       let isQuiz = this.parseBool(this.state.content[this.state.currentSlide].isQuiz) // Converts boolean if isQuiz is a string
       let lastSlide = (this.state.currentSlide + 1 == this.state.content.length) // true if we are on last slide
@@ -69,6 +72,9 @@ export default class Present extends Component {
       }
       if (this.state.currentSlide > 0) { // we are on the first slide
         this.setState({prevDisable: false})
+      }
+      if (this.state.currentSlide < this.state.highestSlide) { // we have already completed this slide
+        this.setState({nextDisable: false})
       }
       this.setState({nextFlag: false}) // we have handled the slide change
     }
@@ -103,6 +109,55 @@ export default class Present extends Component {
     });
   }
 
+  loadSession() {
+    $.ajax({
+      url: './slideshow/Session/' + window.sessionStorage.getItem('id'),
+      type: 'GET',
+      dataType: 'json',
+      success: function (data) {
+        //console.log(data)
+        if (this.state.content != undefined) {
+          let high = parseInt(data.highestSlide)
+          let curr = parseInt(data.highestSlide)
+          const finish = this.parseBool(data.completed)
+          if (curr >= this.state.content.length) {
+            curr = this.state.content.length - 1
+          }
+          this.setState({
+            highestSlide: high,
+            currentSlide: curr,
+            finishFlag: finish,
+            nextFlag: true,
+            quizNextFlag: true,
+            quizPassed: true
+          })
+        }
+      }.bind(this),
+      error: function(req, err) {
+        alert("Failed to load session from db.")
+        console.error(req, err.toString())
+      }.bind(this)
+    })
+  }
+
+  updateSession() {
+    /* Updates the db that saves the users location within the slideshow */
+    $.ajax({
+      url: './slideshow/Session/' + window.sessionStorage.getItem('id'),
+      type: 'PUT',
+      data: {highestSlide: this.state.highestSlide, completed: this.state.finishFlag},
+      dataType: 'json',
+      success: function() {
+        //console.log("session updated successfully")
+      }.bind(this),
+      error: function(req, err) {
+        //console.log("Failed to updated user's session data:")
+        console.error(req, err.toString())
+        alert(req.responseText)
+      }.bind(this)
+    })
+  }
+
   changeSlide(slideNum) {
     let highest = this.state.highestSlide
     if (this.state.highestSlide < slideNum) {
@@ -129,13 +184,12 @@ export default class Present extends Component {
 
   validate() {
     /* this function is only called if the correct answer is chosen */
-    //if (this.state.content[this.state.currentSlide].correctAnswerIndex == answer) {
+
     let finish = this.state.finishFlag
     if (this.state.content.length == this.state.currentSlide + 1) {
       finish = true
     }
-    this.setState({quizPassed: true, finishFlag: finish})
-    //}
+    this.setState({quizPassed: true, finishFlag: finish}, () => this.updateSession())
   }
 
   returnToShowList() {

--- a/javascript/Present/Present.jsx
+++ b/javascript/Present/Present.jsx
@@ -134,7 +134,8 @@ export default class Present extends Component {
         }
       }.bind(this),
       error: function(req, err) {
-        alert("Failed to load session from db.")
+        //alert("Failed to load session from db.")
+        console.log("If you are an admin, disregard the error below:")
         console.error(req, err.toString())
       }.bind(this)
     })

--- a/javascript/View/ShowCard.jsx
+++ b/javascript/View/ShowCard.jsx
@@ -12,14 +12,17 @@ export default class ShowCard extends Component {
     this.state = {
         img: AppLogo,
         active: 0,
+        sessionFlag: 0 // case 0: begin/start
+                      // case 1: continue
+                      // case 2: review
     }
 
+    this.getSessionInfo = this.getSessionInfo.bind(this)
     this.presentTransition = this.presentTransition.bind(this)
   }
 
-  editTransition() {
-   window.sessionStorage.setItem('id', this.props.id)
-   window.location.href = './slideshow/Show/Edit/?id=' + this.props.id
+  componentDidMount() {
+    this.getSessionInfo()
   }
 
   presentTransition() {
@@ -27,8 +30,46 @@ export default class ShowCard extends Component {
     window.location.href = './slideshow/Show/Present/?id=' + this.props.id
   }
 
+  getSessionInfo() {
+    $.ajax({
+      url: './slideshow/Session/' + this.props.id,
+      type: 'GET',
+      dataType: 'json',
+      success: function (data) {
+        console.log(this.props.id)
+        console.log(data)
+        console.log(data.highestSlide)
+        let session = 0
+        if (Number(data.completed)) {
+          session = 2 // Review
+        }
+        else if (Number(data.highestSlide) > 0) {
+          session = 1 // continue
+        }
+
+        this.setState({
+          sessionFlag: session
+        })
+      }.bind(this)
+    })
+  }
+
 
   render() {
+
+    let present = undefined
+    switch (this.state.sessionFlag) {
+      case 0:
+        present = <Button onClick={this.presentTransition} color="primary">Begin</Button>
+        break;
+      case 1:
+        present = <Button onClick={this.presentTransition} color="warning">Continue</Button>
+        break;
+      case 2:
+        present = <Button onClick={this.presentTransition} color="success" >Review</Button>
+        break;
+    }
+
     return (
       <div style={{paddingBottom: "25px"}}>
         <Card>
@@ -40,7 +81,7 @@ export default class ShowCard extends Component {
               {this.props.title}
             </CardTitle>
             <div className="d-flex justify-content-around">
-              <Button onClick={this.presentTransition} color="warning">Complete</Button>
+              {present}
             </div>
           </CardBody>
         </Card>

--- a/javascript/View/ShowCard.jsx
+++ b/javascript/View/ShowCard.jsx
@@ -1,0 +1,58 @@
+import React, {Component} from 'react'
+import PropTypes from 'prop-types'
+import { Card, CardBody, CardTitle, CardImg, Button, Alert } from 'reactstrap'
+import './custom.css'
+
+import AppLogo from "../../img/showimg.png"
+
+export default class ShowCard extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+        img: AppLogo,
+        active: 0,
+    }
+
+    this.presentTransition = this.presentTransition.bind(this)
+  }
+
+  editTransition() {
+   window.sessionStorage.setItem('id', this.props.id)
+   window.location.href = './slideshow/Show/Edit/?id=' + this.props.id
+  }
+
+  presentTransition() {
+    window.sessionStorage.setItem('id', this.props.id)
+    window.location.href = './slideshow/Show/Present/?id=' + this.props.id
+  }
+
+
+  render() {
+    return (
+      <div style={{paddingBottom: "25px"}}>
+        <Card>
+          <div className="card-img-caption">
+            <img className="card-img-top" src={this.state.img}/>
+          </div>
+          <CardBody>
+            <CardTitle className="d-flex justify-content-center">
+              {this.props.title}
+            </CardTitle>
+            <div className="d-flex justify-content-around">
+              <Button onClick={this.presentTransition} color="warning">Complete</Button>
+            </div>
+          </CardBody>
+        </Card>
+      </div>
+    )
+}
+
+}
+
+ShowCard.propTypes = {
+   //id: PropTypes.string,
+   title: PropTypes.string,
+   //active: PropTypes.number,
+   //load: PropTypes.function
+ }

--- a/javascript/View/ShowView.jsx
+++ b/javascript/View/ShowView.jsx
@@ -9,6 +9,7 @@ export default class ShowView extends Component {
       this.state = {
         resource: Show,
         showData: null,
+        //showInactive: true // shows inactive shows when true
       }
 
       this.getData     = this.getData.bind(this)
@@ -43,7 +44,7 @@ export default class ShowView extends Component {
     let cards = undefined
     if (this.state.showData !== null) {
      cards = this.state.showData.map(function(show) {
-        if (show.active == 1) {
+        if (show.active == 1 /*|| this.state.showInactive */) {
           return(
             <ShowCard
                key={show.id}

--- a/javascript/View/ShowView.jsx
+++ b/javascript/View/ShowView.jsx
@@ -1,0 +1,69 @@
+'use strict'
+import React, {Component} from 'react'
+import ShowCard from './ShowCard.jsx'
+import Show from '../Resources/Show.js'
+
+export default class ShowView extends Component {
+  constructor() {
+      super()
+      this.state = {
+        resource: Show,
+        showData: null,
+      }
+
+      this.getData     = this.getData.bind(this)
+    }
+
+  componentDidMount() {
+    this.getData();
+  }
+
+
+  /**
+  * Pulls all the shows from the back-end
+  */
+  getData() {
+    $.ajax({
+      url: './slideshow/Show',
+      type: 'GET',
+      dataType: 'json',
+      success: function(data) {
+        this.setState({showData: data['listing']});
+      }.bind(this),
+      error: function(req, err) {
+
+                //alert("Failed to grab data.")
+        console.error(req, err.toString());
+      }.bind(this)
+    });
+  }
+
+
+  render() {
+    let cards = undefined
+    if (this.state.showData !== null) {
+     cards = this.state.showData.map(function(show) {
+        if (show.active == 1) {
+          return(
+            <ShowCard
+               key={show.id}
+               id={show.id}
+               title={show.title}
+               load={this.getData} />
+           )
+         }}.bind(this)
+      )
+    }
+
+    return (
+      <div>
+        <h2>Shows:</h2>
+        <div className="jumbotron">
+          <div className="card-deck d-flex justify-content-center">
+            {cards}
+          </div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/javascript/View/custom.css
+++ b/javascript/View/custom.css
@@ -1,0 +1,19 @@
+.card-img-caption {
+  border-top-left-radius: calc(.25rem - 1px);
+  border-top-right-radius: calc(.25rem - 1px);
+}
+
+.card-img-top {
+  z-index: 0;
+  max-width: 300px;
+  max-height: 250px;
+  min-width: 300px;
+  min-height: 250px;
+}
+
+.card-img-caption .card-text {
+  position: absolute;
+  top: 0px;
+  right: 5px;
+  height: 5px;
+}

--- a/javascript/View/index.jsx
+++ b/javascript/View/index.jsx
@@ -1,0 +1,7 @@
+'use strict'
+import React from 'react'
+import ReactDOM from 'react-dom'
+import ShowView from './ShowView.jsx'
+
+ReactDOM.render(
+  <ShowView />, document.getElementById('view'))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "slideshow",
-  "version": "1.0.0",
-  "description": "Slideshow module using reveal.js",
+  "version": "1.2.0",
+  "description": "Slideshow-based modules with quiz integration",
   "main": "index.js",
   "dependencies": {
     "canopy-react-buttongroup": "^0.1.5",


### PR DESCRIPTION
# In this Pull Request
## User Roles
#7 - One can now sign in as a logged user and view active slideshows as well as take them 😀 
## Session Handling
As users progress through a slideshow, we save their progress by keeping track of their highest slide. We also keep a tab on whether the user has completed a show. We render different views for SlidesView and ShowCard based on the status of users' progress from their corresponding slideshows. (There are three states of Begin, Continue, and Review.) When a user loads back into a show, the highest slide completed will be rendered.

## Other
- Removed references to Matt's old Slide Resources. 
- Updated Install, uninstall and update within Boost. We are now on Slideshow version 1.2! 
- Added Tables.php 
    - This file cleans up install quite a bit, especially as more tables are added in the future.
### Possible/Known Issues
- When logged in as an admin an ajax request within present will execute to load the session, however we don't store sessions for admins, so it returns an error. This issue is only displayed in the console and does not affect anything negatively. However, in the future we may want to handle this in a more professional way.
- There is a very rare and weird session loading issue where React will render the component at slide 1 rather than at the users current slide. However, this only happens rarely and appears to be an unusually complex fix, which is why I didn't address it. Also, when this happens the user can just go to his/her current slide with little effort on their end.
- If you have a reference to Matt's ss_slide table then there may be an error with updating. You may need to drop the tables and try reinstalling completely.