### PR TITLE
Seperated all slide content into it's own table and corresponding controller/resource/factory

### DIFF
--- a/boost/Tables.php
+++ b/boost/Tables.php
@@ -34,4 +34,10 @@ class Tables
         $session = new \slideshow\Resource\SessionResource;
         return $session->createTable($this->db);
     }
+
+    public function createSlide()
+    {
+        $slide = new \slideshow\Resource\SlideResource;
+        return $slide->createTable($this->db);
+    }
 }

--- a/boost/boost.php
+++ b/boost/boost.php
@@ -18,7 +18,7 @@
  * @license http://opensource.org/licenses/gpl-3.0.html
  */
 $proper_name = 'Slideshow';
-$version = '1.2.1';
+$version = '1.3.0';
 $register = false;
 $unregister = false;
 $import_sql = false;

--- a/boost/boost.php
+++ b/boost/boost.php
@@ -18,7 +18,7 @@
  * @license http://opensource.org/licenses/gpl-3.0.html
  */
 $proper_name = 'Slideshow';
-$version = '1.2.0';
+$version = '1.2.1';
 $register = false;
 $unregister = false;
 $import_sql = false;

--- a/boost/install.php
+++ b/boost/install.php
@@ -15,11 +15,13 @@ function slideshow_install(&$content)
 
     $show;
     $session;
+    $slide;
     try {
         $tables = new slideshow\Tables;
 
         $show = $tables->createShow();
         $session = $tables->createSession();
+        $slide = $tables->createSlide();
 
     } catch (\Exception $e) {
         \phpws2\Error::log($e);
@@ -27,7 +29,8 @@ function slideshow_install(&$content)
 
         $show->drop(true);
         $session->drop(true);
-
+        $slide->drop(true);
+        
         throw $e;
     }
     $db->commit();

--- a/boost/uninstall.php
+++ b/boost/uninstall.php
@@ -26,6 +26,7 @@ function slideshow_uninstall(&$content)
     try {
       $db->buildTable('ss_show')->drop();
       $db->buildTable('ss_session')->drop();
+      $db->buildTable('ss_slide')->drop();
     }
     catch (Exception $e) {
       \phpws2\Error::log($e);

--- a/boost/update.php
+++ b/boost/update.php
@@ -68,17 +68,21 @@ class slideshowUpdate
       $this->addContent('1.2.0', $changes);
   }
 
-  private function v1_2_1()
+  private function v1_3_0()
   {
       $db = \phpws2\Database::getDB();
 
-      // TODO: Pull Show$content and save it here. or drop the table lol.
+      // A fresh install is needed, so a drop will be completed lol
+      $db->buildTable('ss_show')->drop();
+
+      $show = new \slideshow\Resource\ShowResource;
+      $show->createTable($db);
 
       $slide = new \slideshow\Resource\SlideResource;
       $slide->createTable($db);
 
       $changes[] = 'Slide data is pulled out and saved seperately';
-      $this->addContent('1.2.1', $changes);
+      $this->addContent('1.3.0', $changes);
   }
 
   private function addContent($version, array $changes)

--- a/boost/update.php
+++ b/boost/update.php
@@ -28,6 +28,8 @@ class slideshowUpdate
         $this->update('1.1.0');
       case $this->compare('1.2.0'):
         $this->update('1.2.0');
+      case $this->compare('1.2.1'):
+        $this->update('1.2.1');
     }
   }
 
@@ -64,6 +66,19 @@ class slideshowUpdate
 
       $changes[] = 'can now keep track of user progress through the quizzes they take';
       $this->addContent('1.2.0', $changes);
+  }
+
+  private function v1_2_1()
+  {
+      $db = \phpws2\Database::getDB();
+
+      // TODO: Pull Show$content and save it here. or drop the table lol.
+
+      $slide = new \slideshow\Resource\SlideResource;
+      $slide->createTable($db);
+
+      $changes[] = 'Slide data is pulled out and saved seperately';
+      $this->addContent('1.2.1', $changes);
   }
 
   private function addContent($version, array $changes)

--- a/class/Controller/Show/Admin.php
+++ b/class/Controller/Show/Admin.php
@@ -53,8 +53,7 @@ class Admin extends Base
 
     protected function postCommand(Request $request)
     {
-        $show = $this->factory->post($request);
-        return array('show'=>$show->getStringVars());
+        return $this->factory->post($request);
     }
 
     protected function patchCommand(Request $request)

--- a/class/Controller/Show/Admin.php
+++ b/class/Controller/Show/Admin.php
@@ -51,22 +51,6 @@ class Admin extends Base
         return $this->view->adminShow();
     }
 
-    /**
-    * Handles the request to render the edit page.
-    */
-    protected function editHtmlCommand(Request $request)
-    {
-      return $this->view->edit();
-    }
-
-    /**
-    * Handles the request to render the present page.
-    */
-    protected function presentHtmlCommand(Request $request)
-    {
-      return $this->view->present();
-    }
-
     protected function postCommand(Request $request)
     {
         $show = $this->factory->post($request);
@@ -82,31 +66,6 @@ class Admin extends Base
     protected function listJsonCommand(Request $request)
     {
         return array('listing'=>$this->factory->listing(true));
-    }
-
-    protected function editJsonCommand(Request $request)
-    {
-      $vars = $request->getRequestVars();
-      $id = $vars['id'];
-      return array(
-        'slides'=> $this->factory->getSlides($id),
-        'id' => $id
-      );
-    }
-
-    protected function presentJsonCommand(Request $request)
-    {
-      $vars = $request->getRequestVars();
-      $id = $vars['id'];
-      return array(
-        'slides' => $this->factory->getSlides($id),
-        'title' => $this->factory->getShowName($id),
-      );
-    }
-
-    protected function viewHtmlCommand(Request $request)
-    {
-        return 'viewHtmlCommand empty';
     }
 
     protected function deleteCommand(Request $request)
@@ -126,7 +85,7 @@ class Admin extends Base
         return json_encode($shows);
     }
 
-    protected function getJsonView($data, \Canopy\Request $request)
+    protected function getJsonView($data, Request $request)
     {
       $vars = $request->getRequestVars();
       $command = '';

--- a/class/Controller/Slide/Admin.php
+++ b/class/Controller/Slide/Admin.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+* The MIT License
+*
+* Copyright 2018 Tyler Craig <craigta1@appstate.edu>.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+namespace slideshow\Controller\Slide;
+
+use Canopy\Request;
+use slideshow\Factory\Slide;
+
+class Admin extends Base
+{
+
+
+ /**
+ * Returns the slides of a specific slideshow
+ * @var Canopy\Request
+ * @return array of slides
+ */
+ protected function editJsonCommand(Request $request)
+ {
+     // TODO: look at editJsonCommand in Show
+     return $this->factory->get($request);
+ }
+
+ /**
+ *  Edits the values for slides -> happens on a save
+ */
+ protected function putCommand(Request $request)
+ {
+     return $this->factory->put($request);
+ }
+
+ /**
+ * Deletes a table from ss_slide -> happens on a delete
+ */
+ protected function jsonPatchCommand(Request $request)
+ {
+     return $this->factory->patch($request);
+ }
+
+ protected function deleteCommand(Request $request)
+ {
+     return $this->factory->delete($request);
+ }
+
+}

--- a/class/Controller/Slide/Base.php
+++ b/class/Controller/Slide/Base.php
@@ -11,29 +11,29 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * @author Matthew McNaney <mcnaney at gmail dot com>
+ * @author Tyler Craig <craigta1 at appstate dot edu>
  *
  * @license http://opensource.org/licenses/lgpl-3.0.html
  */
 
-namespace slideshow\Controller\Show;
+namespace slideshow\Controller\Slide;
 
 use Canopy\Request;
-use slideshow\Factory\ShowFactory as Factory;
-use slideshow\View\ShowView as View;
+use slideshow\Factory\SlideFactory as Factory;
+use slideshow\View\SlideView as View;
 use slideshow\Controller\RoleController;
 
 class Base extends RoleController
 {
 
     /**
-     * @var slideshow\Factory\ShowFactory
+     * @var slideshow\Factory\SlideFactory
      */
     protected $factory;
 
     /**
-     * @var slideshow\View\ShowView
-     */
+    * @var slideshow\View\SlideView
+    */
     protected $view;
 
     protected function loadFactory()
@@ -44,6 +44,27 @@ class Base extends RoleController
     protected function loadView()
     {
         $this->view = new View;
+    }
+
+    /**
+    * Renders the view for edit
+    */
+    protected function editHtmlCommand(Request $request)
+    {
+        return $this->view->edit();
+    }
+
+    /**
+    * Renders the view for present
+    */
+    protected function presentHtmlCommand(Request $request)
+    {
+        return $this->view->present();
+    }
+
+    protected function presentJsonCommand(Request $request)
+    {
+        return $this->factory->get($request);
     }
 
 }

--- a/class/Controller/Slide/Logged.php
+++ b/class/Controller/Slide/Logged.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * The MIT License
+ *
+ * Copyright 2018 Tyler Craig <craigta1@appstate.edu>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+  namespace slideshow\Controller\Slide;
+
+  use Canopy\Request;
+  use slideshow\Factory\SlideFactory;
+  use slideshow\View\SlideView;
+
+  class Logged extends Base
+  {
+
+  }

--- a/class/Controller/Slide/User.php
+++ b/class/Controller/Slide/User.php
@@ -11,40 +11,13 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * @author Matthew McNaney <mcnaney at gmail dot com>
  *
  * @license http://opensource.org/licenses/lgpl-3.0.html
  */
 
 namespace slideshow\Controller\Show;
 
-use Canopy\Request;
-use slideshow\Factory\ShowFactory;
-use slideshow\View\ShowView;
-
-class Logged extends Base
+class User extends Logged
 {
-  /**
-   * @var slideshow\Factory\ShowFactory
-   */
-  protected $factory;
-
-  /**
-  * @var slideshow\View\ShowView
-  */
-  protected $view;
-
-  /**
-  * Handles the request to render the list page.
-  */
-  protected function listHtmlCommand(Request $request)
-  {
-      return $this->view->show();
-  }
-
-  protected function listJsonCommand(Request $request)
-  {
-      return array('listing'=>$this->factory->listing(true));
-  }
 
 }

--- a/class/Factory/Base.php
+++ b/class/Factory/Base.php
@@ -24,7 +24,8 @@ abstract class Base extends \phpws2\ResourceFactory
         $resource = $this->build();
         $resource->setId($id);
         if (!parent::loadByID($resource)) {
-            throw new ResourceNotFound($id);
+            // Make a new one if it doesn't exist
+            return $this->build();
         }
         return $resource;
     }

--- a/class/Factory/ShowFactory.php
+++ b/class/Factory/ShowFactory.php
@@ -41,7 +41,7 @@ class ShowFactory extends Base
         //$show->content = [];
         $this->saveResource($show);
         //$this->createImageDirectory($show);
-        return $show;
+        return $show->id;
     }
 
     public function put(Request $request)

--- a/class/Factory/SlideFactory.php
+++ b/class/Factory/SlideFactory.php
@@ -1,0 +1,158 @@
+<?php
+
+/*
+* The MIT License
+*
+* Copyright 2018 Tyler Craig <craigta1@appstate.edu>.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy
+* of this software and associated documentation files (the "Software"), to deal
+* in the Software without restriction, including without limitation the rights
+* to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in
+* all copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
+*/
+
+namespace slideshow\Factory;
+
+use slideshow\Resource\SlideResource;
+use phpws2\Database;
+use Canopy\Request;
+
+class SlideFactory extends Base
+{
+
+    protected function build()
+    {
+        return new SlideResource;
+    }
+
+    public function get(Request $request)
+    {
+        $vars = $request->getRequestVars();
+        $showId = $vars['id'];
+
+        $slides = $this->getSlides($showId);
+
+        return array(
+            'slides' => $slides
+            // Backgorund color and other data here
+        );
+    }
+
+    public function post(Request $request)
+    {
+        /*$vars = $request->getRequestVars();
+        $showId = intval($vars['Show']);
+        */
+
+        $resource = $this->build();
+
+        $resource->showId = $request->pullPostVarIfSet('id');
+
+        $this->saveResource($resource);
+        return $resource;
+    }
+
+    /**
+    * Updates the content of the slide or makes a new one
+    * @return SlideResource
+    */
+    public function put(Request $request)
+    {
+        // pull showId from $request
+        $vars = $request->getRequestVars();
+        $showId = intval($vars['Slide']);
+
+        $slideIndex = $request->pullPutVarIfSet('index');
+
+        $resourceId = $this->getResourceId($showId, $slideIndex);
+
+        $resource = null;
+        if (!empty($resourceId)) {
+            $resource = $this->load($resourceId);
+        }
+        else {
+            $resource = $this->build();
+        }
+
+        $resource->showId = $showId;
+        $resource->content = $request->pullPutVarIfSet('content');
+        $resource->slideIndex = $slideIndex;
+        $resource->isQuiz = $request->pullPutVarIfSet('isQuiz');
+        //$resource->backgorundColor = $request->pullPutVarIfSet('color');
+
+        $this->saveResource($resource);
+        return $resource;
+    }
+
+    /**
+    * The patch request is reserved for the deletion of slides
+    * @return boolean true if slide was deleted
+    */
+    public function patch(Request $request)
+    {
+        // pull showId from $request
+        $vars = $request->getRequestVars();
+        $showId = intval($vars['Slide']);
+
+        $slideIndex = $request->pullPatchVarIfSet('index');
+
+        // Build SlideResource from id and index
+        $resourceId = $this->getResourceId($showId, $slideIndex);
+        $resource = $this->load($resourceId);
+
+        return ($this->deleteResource($resource) != 0);
+    }
+
+    public function delete(Request $request)
+    {
+        // Remove all slides comes from Showlist
+        $vars = $request->getRequestVars();
+        $showId = intval($vars['Slide']);
+
+        $sql = 'DELETE from ss_slide WHERE showId=:showId;';
+        $db = Database::getDB();
+        $pdo = $db->getPDO();
+        $q = $pdo->prepare($sql);
+        return $q->execute(array('showId'=>$showId));
+    }
+
+    /**
+    * Returns the slide of the show corresponding to the showId
+    * @var integer showId
+    * @return array of slides
+    */
+    private function getSlides($showId)
+    {
+        $sql = 'SELECT * FROM ss_slide WHERE showId=:showId ORDER BY ss_slide.slideIndex;';
+        $db = Database::getDB();
+        $pdo = $db->getPDO();
+        $q = $pdo->prepare($sql);
+        $q->execute(array('showId'=>$showId));
+        $slides = $q->fetchAll();
+        return $slides;
+    }
+
+    private function getResourceId($showId, $slideIndex)
+    {
+        $db = Database::getDB();
+        $sql = 'SELECT id FROM ss_slide WHERE showId=:showId AND slideIndex=:slideIndex;';
+        $pdo = $db->getPDO();
+        $q = $pdo->prepare($sql);
+        $q->execute(array('showId'=>$showId, 'slideIndex'=>$slideIndex));
+        return $q->fetchColumn();
+    }
+
+}

--- a/class/Resource/SessionResource.php
+++ b/class/Resource/SessionResource.php
@@ -49,7 +49,7 @@ class SessionResource extends BaseAbstract
     public function __construct()
     {
         parent::__construct();
-        $this->userId = new\phpws2\Variable\IntegerVar(\Current_User::getId(), 'userId');
+        $this->userId = new \phpws2\Variable\IntegerVar(\Current_User::getId(), 'userId');
         $this->showId = new \phpws2\Variable\IntegerVar(0, 'showId');
         $this->highestSlide = new \phpws2\Variable\SmallInteger(0, 'highestSlide');
         $this->completed = new \phpws2\Variable\BooleanVar(false, 'completed');

--- a/class/Resource/ShowResource.php
+++ b/class/Resource/ShowResource.php
@@ -33,12 +33,6 @@ class ShowResource extends BaseAbstract
      */
     protected $active;
 
-    /**
-     *
-     * Data for each silde
-     * @var \phpws2\Variable\StringVar
-     */
-    protected $content;
 
     protected $table = 'ss_show';
 
@@ -48,7 +42,7 @@ class ShowResource extends BaseAbstract
         $this->title = new \phpws2\Variable\StringVar(null, 'title');
         $this->title->setLimit('255');
         $this->active = new \phpws2\Variable\BooleanVar(0, 'active');
-        $this->content = new \phpws2\Variable\StringVar(null, 'content');
+        // TODO: slideshow timer
     }
 
     public function getImagePath()

--- a/class/Resource/SlideResource.php
+++ b/class/Resource/SlideResource.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * See docs/AUTHORS and docs/COPYRIGHT for relevant info.
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @author Tyler Craig <craigta1 at appstate dot edu>
+ *
+ * @license http://opensource.org/licenses/lgpl-3.0.html
+ */
+
+namespace slideshow\Resource;
+
+class SlideResource extends BaseAbstract
+{
+
+    protected $table = 'ss_slide';
+
+    /**
+    * SlideShow id
+    * @var phpws2\Variable\IntegerVar
+    */
+    protected $showId;
+
+    /**
+    * Slide index
+    * Note: think of this as a sequential id for the slides:
+    * If a slide at index 2 gets deleted, then slide at index 3 will not get decremented
+    * @var phpws2\Variable\SmallInteger
+    */
+    protected $slideIndex;
+
+    /**
+    * Slide Content
+    * @var phpws2\Variable\StringVar
+    */
+    protected $content;
+
+    /**
+    * Slide is a quiz
+    * @var phpws2\Variable\BooleanVar
+    */
+    protected $isQuiz;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->showId = new \phpws2\Variable\IntegerVar(0, 'showId');
+        $this->slideIndex = new \phpws2\Variable\SmallInteger(0, 'slideIndex');
+        $this->content = new \phpws2\Variable\StringVar(null, 'content');
+        $this->isQuiz = new \phpws2\Variable\BooleanVar(0, 'isQuiz');
+    }
+
+}

--- a/class/View/ShowView.php
+++ b/class/View/ShowView.php
@@ -29,16 +29,7 @@
      return $this->scriptView('shows');
    }
 
-   public function edit()
-   {
-      return $this->scriptView('edit');
-   }
-
-   public function present()
-   {
-     return $this->scriptView('present');
-   }
-
+   /* DEPRECATED
    private function createShowButton()
     {
         $nav = new NavBar();
@@ -46,5 +37,5 @@
 <button class="btn btn-success navbar-btn" id="createShow"><i class="fa fa-plus"></i> Create New SlideShow</button>
 EOF;
         $nav->addItem($create);
-    }
+    } */
  }

--- a/class/View/SlideView.php
+++ b/class/View/SlideView.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * MIT License
+ * Copyright (c) 2018 Electronic Student Services @ Appalachian State University
+ *
+ * See LICENSE file in root directory for copyright and distribution permissions.
+ *
+ * @author Tyler Craig <craigta1@appstae.edu>
+ * @license https://opensource.org/licenses/MIT
+ */
+
+ namespace slideshow\View;
+
+ class SlideView extends BaseView
+ {
+
+     public function edit()
+     {
+         return $this->scriptView('edit');
+     }
+
+     public function present()
+     {
+         return $this->scriptView('present');
+     }
+     
+ }

--- a/javascript/Edit/Edit.jsx
+++ b/javascript/Edit/Edit.jsx
@@ -10,7 +10,7 @@ export default class Edit extends Component {
 
     this.state = {
       currentSlide: 0,
-      id: -1,
+      id: window.sessionStorage.getItem('id'),
       content: [
         {
           saveContent: undefined,

--- a/javascript/Edit/Edit.jsx
+++ b/javascript/Edit/Edit.jsx
@@ -24,7 +24,6 @@ export default class Edit extends Component {
 
     this.save = this.save.bind(this)
     this.load = this.load.bind(this)
-    this.redirect = this.redirect.bind(this)
     this.setCurrentSlide = this.setCurrentSlide.bind(this)
     this.addNewSlide = this.addNewSlide.bind(this)
     this.addNewQuiz = this.addNewQuiz.bind(this)
@@ -99,22 +98,6 @@ export default class Edit extends Component {
     });
   }
 
-
-  redirect(url) {
-    $.ajax({
-      url: './slideshow/Show/' + window.sessionStorage.getItem('id'),
-      data: {content: this.state.content},
-      type: 'put',
-      dataType: 'json',
-      success: function() {
-        window.location.href = url
-      }.bind(this),
-      error: function(req, err) {
-        alert("Failed to save show " + window.sessionStorage.getItem('id'))
-        console.error(req, err.toString());
-      }.bind(this)
-    });
-  }
 
   setCurrentSlide(val) {
     this.save()
@@ -220,8 +203,7 @@ export default class Edit extends Component {
           addToStack        ={this.addToStack}
           currentSlide      ={this.state.currentSlide}
           insertQuiz        ={this.addNewQuiz}
-          saveDB            ={this.save}
-          redirect          ={this.redirect}/>
+          saveDB            ={this.save}/>
         <div className="row">
           <SlidesView
             slides          ={this.state.content}

--- a/javascript/Edit/Edit.jsx
+++ b/javascript/Edit/Edit.jsx
@@ -16,7 +16,7 @@ export default class Edit extends Component {
           saveContent: undefined,
           quizContent: undefined,
           isQuiz: false,
-          id: 0
+          id: 0 // This is an indexable id for saving and delteing slides
         },
       ],
     }
@@ -37,35 +37,57 @@ export default class Edit extends Component {
     this.load()
   }
 
-
   save() {
+    let c = this.state.content[this.state.currentSlide].isQuiz ?
+          /* if quiz */ this.state.content[this.state.currentSlide].quizContent :
+          /* else    */ this.state.content[this.state.currentSlide].saveContent
     $.ajax({
-      url: './slideshow/Show/' + window.sessionStorage.getItem('id'),
-      data: {content: this.state.content},
+      url: './slideshow/Slide/' + window.sessionStorage.getItem('id'),
+      data: {
+        content: c,
+        index: this.state.content[this.state.currentSlide].id,
+        isQuiz: this.state.content[this.state.currentSlide].isQuiz
+      },
       type: 'put',
       dataType: 'json',
-      success: function() {
-        this.load();
-      }.bind(this),
-      error: function(req, err) {
+      error: (req, err) => {
         alert("Failed to save show " + window.sessionStorage.getItem('id'))
+        document.write(req.responseJSON.backtrace[0].args[1].xdebug_message)
         console.error(req, err.toString());
-      }.bind(this)
-    });
+      }
+    })
   }
 
 
   load() {
     $.ajax({
-      url: './slideshow/Show/edit/?id=' + window.sessionStorage.getItem('id'),
+      url: './slideshow/Slide/edit/?id=' + window.sessionStorage.getItem('id'),
       type: 'GET',
       dataType: 'json',
       success: function (data) {
         let loaded = data['slides']
-        if (loaded != null) {
+        if (loaded[0] != undefined) {
+          let showContent = []
+          for (let i = 0; i < loaded.length; i++) {
+            let saveC = undefined
+            let quizC = undefined
+            let isQ = this.quizConv(loaded[i].isQuiz)
+            if (!isQ) {
+              saveC = loaded[i].content
+            } else {
+              quizC = loaded[i].content
+            }
+            showContent.push({
+              isQuiz: isQ,
+              saveContent: saveC,
+              quizContent: quizC,
+              id: loaded[i].slideIndex // This may not be needed
+            })
+          }
+
           this.setState({
-            content: loaded,
-            id: data['id']
+            content: showContent,
+            id: loaded[0].showId
           });
         }
       }.bind(this),
@@ -78,6 +100,7 @@ export default class Edit extends Component {
 
 
   setCurrentSlide(val) {
+    this.save()
     this.setState({
       currentSlide: val
     })
@@ -88,16 +111,18 @@ export default class Edit extends Component {
     if (typeof(quiz) === 'object') quiz = false // an event is bindinded on some calls which causes errors
     /* This function adds to the stack of slides held within state.content */
     const index = this.state.currentSlide + 1
+    const newId = Number(this.state.content[this.state.currentSlide].id) + 1
     const newSlide = {
         saveContent: undefined,
         quizContent: undefined,
-        isQuiz: quiz
+        isQuiz: quiz,
+        id: newId
     }
     let copy = [...this.state.content]
     copy.splice(index, 0, newSlide)
     this.setState({
+      currentSlide: index,
       content: copy,
-      currentSlide: index
     })
   }
 
@@ -122,6 +147,15 @@ export default class Edit extends Component {
     if (this.state.currentSlide == copy.length) {
       newIndex = this.state.currentSlide - 1
     }
+
+    $.ajax({
+      url: './slideshow/Slide/' + window.sessionStorage.getItem('id'),
+      type: 'patch',
+      data: {index: this.state.content[this.state.currentSlide].id},
+      error: (req, res) => {
+        console.error(req, res.toString());
+      }
+    })
 
     this.setState({
       content: copy,
@@ -148,10 +182,11 @@ export default class Edit extends Component {
   }
 
   quizConv(quizT) {
-    // When we load from the data base the isQuiz boolean is loaded in as a string
+    // When we load from the data base the isQuiz boolean
+    // is loaded in as a string or a number
     // We need to handle that and bring it back to a boolean
-    // There might be another simpler way around this somewhere else in the code.
     if (quizT == undefined) return false // initial load
+    if (typeof(quizT) === 'number') return (quizT != 0)
     return (typeof(quizT) === "boolean") ? quizT : JSON.parse(quizT)
   }
 
@@ -175,8 +210,7 @@ export default class Edit extends Component {
             slides          ={this.state.content}
             currentSlide    ={this.state.currentSlide}
             setCurrentSlide ={this.setCurrentSlide}
-            addNewSlide     ={this.addNewSlide}
-            saveDB          ={this.save}/>
+            addNewSlide     ={this.addNewSlide}/>
           <EditView
             currentSlide    ={this.state.currentSlide}
             content         ={this.state.content[this.state.currentSlide]}

--- a/javascript/Edit/NavBar.jsx
+++ b/javascript/Edit/NavBar.jsx
@@ -25,8 +25,14 @@ export default class NavBar extends Component {
   }
 
   handlePresent() {
-    window.sessionStorage.setItem('id', this.props.id)
-    window.location.href = './slideshow/Slide/present/?id=' + this.props.id
+    if (this.props.id == -1) {
+      alert("A problem has occurred with your browser's session. This is most likely caused by an attempt to present an empty show.")
+      //window.location.href = './slideshow/Show/list'
+    }
+    else {
+      window.sessionStorage.setItem('id', this.props.id)
+      window.location.href = './slideshow/Slide/Present/?id=' + this.props.id
+    }
   }
 
   render() {

--- a/javascript/Edit/NavBar.jsx
+++ b/javascript/Edit/NavBar.jsx
@@ -30,8 +30,9 @@ export default class NavBar extends Component {
       //window.location.href = './slideshow/Show/list'
     }
     else {
+      this.props.saveDB()
       window.sessionStorage.setItem('id', this.props.id)
-      window.location.href = './slideshow/Slide/Present/?id=' + this.props.id
+      window.setInterval(() => window.location.href = './slideshow/Slide/Present/?id=' + this.props.id, 100)
     }
   }
 
@@ -64,7 +65,6 @@ NavBar.propTypes = {
   insertSlide: PropTypes.func,
   deleteSlide: PropTypes.func,
   currentSlide: PropTypes.number,
-  redirect: PropTypes.func,
   saveDB: PropTypes.func,
   id: PropTypes.number,
 }

--- a/javascript/Edit/NavBar.jsx
+++ b/javascript/Edit/NavBar.jsx
@@ -18,7 +18,7 @@ export default class NavBar extends Component {
   }
 
   returnToShowList() {
-    this.props.save()
+    this.props.saveDB()
     // This inteval fixes a bug on firefox where the browser loads faster than it can save
     window.setInterval(()=> {window.location.href = './slideshow/Show/list'}, 100)
 

--- a/javascript/Edit/NavBar.jsx
+++ b/javascript/Edit/NavBar.jsx
@@ -19,13 +19,15 @@ export default class NavBar extends Component {
 
   returnToShowList() {
     this.props.save()
-    window.location.href = './slideshow/Show/list'
+    // This inteval fixes a bug on firefox where the browser loads faster than it can save
+    window.setInterval(()=> {window.location.href = './slideshow/Show/list'}, 100)
+
   }
 
   handlePresent() {
     this.props.save()
     window.sessionStorage.setItem('id', this.props.id)
-    window.location.href = './slideshow/Show/Present/?id=' + this.props.id
+    window.location.href = './slideshow/Slide/present/?id=' + this.props.id
   }
 
   render() {

--- a/javascript/Edit/Quiz/QuizCreateForm.jsx
+++ b/javascript/Edit/Quiz/QuizCreateForm.jsx
@@ -57,7 +57,7 @@ export default class QuizCreateForm extends Component {
 
   componentDidMount() {
     if (this.props.quizContent != undefined) {
-      this.setState({quizContent: this.props.quizContent}, () => {
+      this.setState({quizContent: JSON.parse(this.props.quizContent)}, () => {
         this.load()
       })
     }
@@ -76,7 +76,7 @@ export default class QuizCreateForm extends Component {
       })
     }
     // save answers
-    this.props.saveQC(nqContent)
+    this.props.saveQC(JSON.stringify(nqContent))
     // save slide show
     this.props.saveDB()
   }
@@ -322,7 +322,7 @@ export default class QuizCreateForm extends Component {
 }
 
 QuizCreateForm.propTypes = {
-  quizContent: PropTypes.object,
+  quizContent: PropTypes.string,
   saveQC: PropTypes.func,
   toggle: PropTypes.func,
   saveDB: PropTypes.func,

--- a/javascript/Edit/Quiz/QuizView.jsx
+++ b/javascript/Edit/Quiz/QuizView.jsx
@@ -19,7 +19,7 @@ export default class QuizView extends Component {
   componentDidMount() {
     if (this.props.quizContent != undefined) {
       this.setState({
-        quizContent: this.props.quizContent
+        quizContent: JSON.parse(this.props.quizContent)
       })
     }
   }
@@ -27,7 +27,7 @@ export default class QuizView extends Component {
   componentDidUpdate(prevProps) {
     if (this.props.quizContent != prevProps.quizContent && this.props.quizContent != undefined) {
       this.setState({
-        quizContent: this.props.quizContent
+        quizContent: JSON.parse(this.props.quizContent)
       })
     }
   }
@@ -60,6 +60,6 @@ export default class QuizView extends Component {
 }
 
 QuizView.propTypes = {
-  quizContent: PropTypes.object,
+  quizContent: PropTypes.string,
   toggle: PropTypes.func
 }

--- a/javascript/Edit/SlidesView.jsx
+++ b/javascript/Edit/SlidesView.jsx
@@ -14,7 +14,6 @@ export default class SlidesView extends Component {
   }
 
   handleSlide(event) {
-    this.props.saveDB()
     this.props.setCurrentSlide(event.target.value - 1)
   }
 
@@ -51,5 +50,4 @@ SlidesView.propTypes = {
   currentSlide: PropTypes.number,
   setCurrentSlide: PropTypes.func,
   addNewSlide: PropTypes.func,
-  saveDB: PropTypes.func,
 }

--- a/javascript/Present/Present.jsx
+++ b/javascript/Present/Present.jsx
@@ -117,7 +117,6 @@ export default class Present extends Component {
             slideName: data['title'],
             quizNextFlag: this.parseBool(showContent[0].isQuiz) // First slide is a quiz
           }, () => {
-            console.log(this.state.content)
             if (!this.state.quizNextFlag) {
               // First slide isn't a quiz we set timer on next
               setTimeout(() => {
@@ -140,7 +139,6 @@ export default class Present extends Component {
       type: 'GET',
       dataType: 'json',
       success: function (data) {
-        //console.log(data)
         if (data.highestSlide != null) {
           let high = parseInt(data.highestSlide)
           let curr = parseInt(data.highestSlide)
@@ -159,9 +157,8 @@ export default class Present extends Component {
         }
       }.bind(this),
       error: function(req, err) {
-        //alert("Failed to load session from db.")
-        //console.log("If you are an admin, disregard the error below:")
-        console.error(req, err.toString())
+        console.log("Failed to load session from db. This could be due to being logged in as an admin")
+        //console.error(req, err.toString())
       }.bind(this)
     })
   }
@@ -177,8 +174,7 @@ export default class Present extends Component {
         //console.log("session updated successfully")
       }.bind(this),
       error: function(req, err) {
-        //console.log("Failed to updated user's session data:")
-        //console.log(this.state.highestSlide)
+        console.log("Failed to updated user's session data:")
         console.error(req, err.toString())
         alert(req.responseText)
       }.bind(this)
@@ -225,7 +221,6 @@ export default class Present extends Component {
 
   parseBool(bool) {
     if (bool == undefined) return false
-    console.log("bool: " + typeof(bool) + " value: " + bool)
     if (typeof(bool) === "string") return (Number(bool) != 0)
     if (typeof(bool) === 'number') return (bool != 0)
     return (typeof(bool) === "boolean") ? bool : JSON.parse(bool)
@@ -246,9 +241,6 @@ export default class Present extends Component {
         )
       }
     }.bind(this));
-    /*console.log("curr: " + this.state.currentSlide)
-    console.log("len: " + this.state.content.length)
-    console.log(this.state.currentSlide + 1 == this.state.content.length)*/
     let nextButton = (this.state.finishFlag) ?
       <button key="finish" className="btn btn-secondary" onClick={this.returnToShowList} disabled={this.state.nextDisable}>Finish</button> :
       <button key="next" className="btn btn-secondary" onClick={this.next} disabled={this.state.nextDisable}>Next</button>

--- a/javascript/Present/PresentView.jsx
+++ b/javascript/Present/PresentView.jsx
@@ -16,21 +16,24 @@ export default class PresentView extends Component {
   }
 
   render() {
-    let viewspace = (this.parseQ(this.props.content.isQuiz)) ?
-      (<QuizViewspace
-        content={this.props.content}
-        currentSlide={this.props.currentSlide}
-        highestSlide={this.props.high}
-        next={this.props.nextSlide}
-        validate={this.props.validate} />) :
-      <Viewspace content={this.props.content} />
-    return (
-      <div className="mh-100">
-        <div className="jumbotron" style={{minHeight: 350}}>
-          {viewspace}
+    if (this.props.content != undefined) {
+      let viewspace = (this.parseQ(this.props.content.isQuiz)) ?
+        (<QuizViewspace
+          content={this.props.content}
+          currentSlide={this.props.currentSlide}
+          highestSlide={this.props.high}
+          next={this.props.nextSlide}
+          validate={this.props.validate} />) :
+        <Viewspace content={this.props.content} />
+      return (
+        <div className="mh-100">
+          <div className="jumbotron" style={{minHeight: 350}}>
+            {viewspace}
+          </div>
         </div>
-      </div>
-    )
+      )
+    }
+    return null
   }
 }
 

--- a/javascript/Present/QuizViewspace.jsx
+++ b/javascript/Present/QuizViewspace.jsx
@@ -31,10 +31,11 @@ export default class QuizViewspace extends Component {
   }
 
   validate(event) {
+    let qContent = JSON.parse(this.props.content.quizContent)
     let ids = event.target.id.split('-')
     if (ids[0] === 'select') {
       // MultipleChoice
-      if (ids[1] == this.props.content.quizContent.correctAnswerIndex) {
+      if (ids[1] == qContent.correctAnswerIndex) {
         this.props.validate()
         this.toggleCorrectAlert()
       }
@@ -53,13 +54,14 @@ export default class QuizViewspace extends Component {
   }
 
   buildAnswerComponent() {
-    if (this.props.content.quizContent != undefined) {
+    let qContent = JSON.parse(this.props.content.quizContent)
+    if (qContent != undefined) {
       let i = -1
-      let a = this.props.content.quizContent.answers.map((answer) => {
+      let a = qContent.answers.map((answer) => {
         i += 1
 
         // Shows a check if the answer has been correctly answered before
-        let c = this.props.content.quizContent.correctAnswerIndex
+        let c = qContent.correctAnswerIndex
         let ans = ((this.props.currentSlide < this.props.highestSlide) && (c == i)) ?
           (<span>{answer} <i className="fas fa-check-circle" style={{color: 'green'}}></i></span>) : answer
 
@@ -84,6 +86,7 @@ export default class QuizViewspace extends Component {
   }
 
   render() {
+    let qContent = JSON.parse(this.props.content.quizContent)
     let alert = undefined
     if (this.state.correct) {
       alert = (<Alert key={this.state.currentSlide} variant="success">
@@ -99,7 +102,7 @@ export default class QuizViewspace extends Component {
 
     let answersComponent = undefined
     let titleComponent = undefined
-    if (this.props.content.quizContent == undefined) {
+    if (qContent == undefined) {
       titleComponent = "Error - Empty Quiz"
       answersComponent = (<div>
                             <p style={{color: 'red'}}>This quiz slide has not been filled with data</p>
@@ -111,7 +114,7 @@ export default class QuizViewspace extends Component {
     }
     else {
      answersComponent = this.buildAnswerComponent()
-     titleComponent = this.props.content.quizContent.questionTitle
+     titleComponent = qContent.questionTitle
     }
     return (
       <div>

--- a/javascript/Present/Viewspace.jsx
+++ b/javascript/Present/Viewspace.jsx
@@ -19,7 +19,7 @@ export default class Viewspace extends Component {
     }
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     if (prevProps.content.saveContent != this.props.content.saveContent) {
       this.loadEditorState()
     }

--- a/javascript/Show/ShowCard.jsx
+++ b/javascript/Show/ShowCard.jsx
@@ -56,6 +56,15 @@ export default class ShowCard extends Component {
 
  deleteShow() {
    $.ajax({
+     url: './slideshow/Slide/' + this.state.id,
+     type: 'delete',
+     dataType: 'json',
+     error: (req, res) => {
+       console.log("Error Deleting Slides")
+       console.error(req, res.toString())
+     }
+   })
+   $.ajax({
      url: './slideshow/Show/' + this.state.id,
      type: 'delete',
      dataType: 'json',
@@ -86,12 +95,12 @@ export default class ShowCard extends Component {
 
  editTransition() {
    window.sessionStorage.setItem('id', this.state.id)
-   window.location.href = './slideshow/Show/Edit/?id=' + this.state.id
+   window.location.href = './slideshow/Slide/Edit/'
  }
 
  presentTransition() {
    window.sessionStorage.setItem('id', this.state.id)
-   window.location.href = './slideshow/Show/Present/?id=' + this.state.id
+   window.location.href = './slideshow/Slide/Present/'
  }
 
  deleteAlert() {

--- a/javascript/Show/ShowView.jsx
+++ b/javascript/Show/ShowView.jsx
@@ -35,7 +35,7 @@ export default class ShowView extends Component {
         dataType: 'json',
         success: function(showId) {
           window.sessionStorage.setItem('id', showId)
-          window.location.href = './slideshow/Slide/Edit'
+          window.setInterval(() => window.location.href = './slideshow/Slide/Edit', 200)
         }.bind(this),
         error: function(req, err) {
           alert("Failed to save data.")

--- a/javascript/Show/ShowView.jsx
+++ b/javascript/Show/ShowView.jsx
@@ -27,6 +27,7 @@ export default class ShowView extends Component {
 
   saveNewShow() {
     if (this.state.resource.title != null) {
+      // new show
       $.ajax({
         url: './slideshow/Show',
         data: this.state.resource,

--- a/javascript/Show/ShowView.jsx
+++ b/javascript/Show/ShowView.jsx
@@ -33,9 +33,9 @@ export default class ShowView extends Component {
         data: this.state.resource,
         type: 'post',
         dataType: 'json',
-        success: function() {
-          this.switchModal()
-          this.getData()
+        success: function(showId) {
+          window.sessionStorage.setItem('id', showId)
+          window.location.href = './slideshow/Slide/Edit'
         }.bind(this),
         error: function(req, err) {
           alert("Failed to save data.")

--- a/javascript/View/ShowCard.jsx
+++ b/javascript/View/ShowCard.jsx
@@ -27,7 +27,7 @@ export default class ShowCard extends Component {
 
   presentTransition() {
     window.sessionStorage.setItem('id', this.props.id)
-    window.location.href = './slideshow/Show/Present/?id=' + this.props.id
+    window.location.href = './slideshow/Slide/Present/'
   }
 
   getSessionInfo() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slideshow",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Slideshow-based modules with quiz integration",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
#5 
# In this pull request
I pulled out all the content from ss_show and made it into it's own table. This update is massive and will allow us to do much more with Slideshow. The main difference is that content is no longer saved with the show; it's saved as its own slide data. The changes may not be apparent when using Slideshow, but almost everything about the back-end has changed. Every back-end request within Edit and Present now go through a different controller which respond to saving into a different table (ss_slide). The way this update sets up the back end the way we should have written Slideshow the first time, however hindsight is 20/20.

Note: I have tried my very best to find bugs. Due to the nature of how big this update is there may be more bugs. Also, rebasing is most likely going to happen so I can help walk you through that if needed. 
 