### PR TITLE
Navigation Cards and New Edit Quiz Ui

### DIFF
--- a/boost/boost.php
+++ b/boost/boost.php
@@ -18,7 +18,7 @@
  * @license http://opensource.org/licenses/gpl-3.0.html
  */
 $proper_name = 'Slideshow';
-$version = '1.3.2';
+$version = '1.3.3';
 $register = false;
 $unregister = false;
 $import_sql = false;

--- a/boost/update.php
+++ b/boost/update.php
@@ -34,6 +34,8 @@ class slideshowUpdate
                 $this->update('1.3.1');
             case $this->compare('1.3.2'):
                 $this->update('1.3.2');
+            case $this->compare('1.3.3'):
+                $this->update('1.3.3');
         }
     }
 
@@ -118,6 +120,19 @@ class slideshowUpdate
 
         $changes[] = 'can now add media to slides';
         $this->addContent('1.3.2', $changes);
+    }
+
+    private function v1_3_3()
+    {
+        $db = \phpws2\Database::getDB();
+
+        $t = $db->addTable('ss_slide');
+        $dt = new \phpws2\Database\Datatype\Varchar($t, 'thumb');
+        $dt->setDefault(null);
+        $dt->add();
+
+        $changes[] = 'thumbnail support';
+        $this->addContent('1.3.3', $changes);
     }
 
     private function addContent($version, array $changes)

--- a/class/Controller/Slide/Admin.php
+++ b/class/Controller/Slide/Admin.php
@@ -70,4 +70,10 @@ class Admin extends Base
  {
      return $this->factory->postImage($request);
  }
+
+ protected function thumbPostCommand(Request $request)
+ {
+     return $this->factory->postThumb($request);
+ }
+ 
 }

--- a/class/Resource/SlideResource.php
+++ b/class/Resource/SlideResource.php
@@ -61,6 +61,12 @@ class SlideResource extends BaseAbstract
     */
     protected $media;
 
+    /**
+    * Thumbnail for the slide (img preview of the slideshow content)
+    * @var phpws2\Variable\StringVar
+    */
+    protected $thumb;
+
     public function __construct()
     {
         parent::__construct();
@@ -70,6 +76,7 @@ class SlideResource extends BaseAbstract
         $this->isQuiz = new \phpws2\Variable\BooleanVar(0, 'isQuiz');
         $this->backgroundColor = new \phpws2\Variable\StringVar('#E5E7E9', 'backgroundColor');
         $this->media = new \phpws2\Variable\StringVar(null, 'media');
+        $this->thumb = new \phpws2\Variable\StringVar(null, 'thumb');
     }
 
 }

--- a/javascript/Edit/EditView.jsx
+++ b/javascript/Edit/EditView.jsx
@@ -44,7 +44,6 @@ export default class EditView extends Component {
     this.saveQuizContent = this.saveQuizContent.bind(this)
     this.toggleQuizEdit = this.toggleQuizEdit.bind(this)
     this.alignMedia = this.alignMedia.bind(this)
-    this.takeDomScreen = this.takeDomScreen.bind(this)
   }
 
   componentDidMount() {
@@ -64,7 +63,6 @@ export default class EditView extends Component {
       }
       else if (this.state.updated) {
         // current component updated
-        this.takeDomScreen()
         this.saveEditorState()
         this.setState({ updated: false })
       }
@@ -115,14 +113,12 @@ export default class EditView extends Component {
       let contentState = this.state.editorState.getCurrentContent()
       let saveContent = JSON.stringify(convertToRaw(contentState))
 
-      this.takeDomScreen()
       this.props.saveContentState(saveContent)
     }
   }
 
   saveQuizContent(quizContent) {
     this.toggleQuizEdit()
-    this.takeDomScreen()
     this.props.saveQuizContent(quizContent)
   }
 
@@ -186,10 +182,6 @@ export default class EditView extends Component {
     }
   }
 
-  takeDomScreen() {
-    var node = document.getElementById('editor')
-    this.props.saveThumb(node)
-  }
 
   render() {
 
@@ -243,7 +235,7 @@ export default class EditView extends Component {
         <div style={{minWidth: 700}}>
           {toolbar}
           <span><br /></span>
-          <div id="editor" className="jumbotron" style={{ minHeight: 450, position: 'relative', backgroundColor: this.props.content.backgroundColor}}>
+          <div id="editor" data-key={this.props.currentSlide} className="jumbotron" style={{ minHeight: 450, position: 'relative', backgroundColor: this.props.content.backgroundColor}}>
             <div className="row">
               {(this.state.mediaAlign === 'left') ? imgRender : undefined}
               <div className="col">

--- a/javascript/Edit/EditView.jsx
+++ b/javascript/Edit/EditView.jsx
@@ -9,6 +9,7 @@ import QuizEdit from './Quiz/QuizEdit.jsx'
 import QuizView from './Quiz/QuizView.jsx'
 
 import ToolbarC from './Toolbar/Toolbar.jsx'
+import ToolbarQ from './Toolbar/QuizToolbar.jsx'
 import ImageC from '../AddOn/ImageColumn.jsx'
 import CustomStyleMap from '../Resources/CustomStyleMap.js';
 import decorator from '../Resources/LinkDecorator.js'
@@ -43,6 +44,7 @@ export default class EditView extends Component {
     this.saveQuizContent = this.saveQuizContent.bind(this)
     this.toggleQuizEdit = this.toggleQuizEdit.bind(this)
     this.alignMedia = this.alignMedia.bind(this)
+    this.takeDomScreen = this.takeDomScreen.bind(this)
   }
 
   componentDidMount() {
@@ -62,6 +64,7 @@ export default class EditView extends Component {
       }
       else if (this.state.updated) {
         // current component updated
+        this.takeDomScreen()
         this.saveEditorState()
         this.setState({ updated: false })
       }
@@ -98,7 +101,7 @@ export default class EditView extends Component {
           this.onEditChange(EditorState.createWithContent(contentState, decorator))
         }
         else {
-          alert("An error has occured. Your data may have been corrupted. This slide will be reset.")
+          console.log("An error has occured. Your data may have been corrupted. This slide will be reset.")
           const eState = EditorState.createWithContent(ContentState.createFromText("New Slide"), decorator)
           this.onEditChange(RichUtils.toggleBlockType(eState, 'header-one'))
         }
@@ -112,12 +115,14 @@ export default class EditView extends Component {
       let contentState = this.state.editorState.getCurrentContent()
       let saveContent = JSON.stringify(convertToRaw(contentState))
 
+      this.takeDomScreen()
       this.props.saveContentState(saveContent)
     }
   }
 
   saveQuizContent(quizContent) {
     this.toggleQuizEdit()
+    this.takeDomScreen()
     this.props.saveQuizContent(quizContent)
   }
 
@@ -181,6 +186,11 @@ export default class EditView extends Component {
     }
   }
 
+  takeDomScreen() {
+    var node = document.getElementById('editor')
+    this.props.saveThumb(node)
+  }
+
   render() {
 
     var editorStyle = {
@@ -223,22 +233,25 @@ export default class EditView extends Component {
     let imgRender = (this.state.imgUrl != undefined) ?
                             <ImageC key={this.state.imgUrl} src={this.state.imgUrl} remove={this.props.removeMedia} align={this.alignMedia} mediaAlign={this.state.mediaAlign} height={'100%'} width={'100%'}/> // Note: we can custom the width and length through these fields
                             : undefined
-    let toolbar = (this.props.isQuiz) ? undefined : 
+    let toolbar = (this.props.isQuiz) ?  
+      <ToolbarQ toggleQuizEdit={this.toggleQuizEdit} view={this.state.quizEditView} />:
       <ToolbarC setEditorState={this.onEditChange} getEditorState={() => this.state.editorState} saveMedia={this.props.saveMedia}/>
      
     return (
-      <div className="col-8" style={{ minWidth: 700 }}>
+      <div className="col">
         <p></p>
-        {toolbar}
-        <span><br /></span>
-        <div className="jumbotron" style={{minHeight: 350, backgroundColor: this.props.content.backgroundColor}}>
-          <div className="row">
-            {(this.state.mediaAlign === 'left') ? imgRender : undefined}
-            <div className="col">
-              {editRender}
-            </div>
-            {(this.state.mediaAlign === 'right') ? imgRender : undefined}
-            </div>
+        <div style={{minWidth: 700}}>
+          {toolbar}
+          <span><br /></span>
+          <div id="editor" className="jumbotron" style={{ minHeight: 450, position: 'relative', backgroundColor: this.props.content.backgroundColor}}>
+            <div className="row">
+              {(this.state.mediaAlign === 'left') ? imgRender : undefined}
+              <div className="col">
+                {editRender}
+              </div>
+              {(this.state.mediaAlign === 'right') ? imgRender : undefined}
+              </div>
+          </div>
         </div>
       </div>
     )
@@ -255,5 +268,6 @@ EditView.propTypes = {
   saveDB: PropTypes.func,
   load: PropTypes.func,
   saveMedia: PropTypes.func,
-  removeMedia: PropTypes.func
+  removeMedia: PropTypes.func,
+  saveThumb: PropTypes.func
 }

--- a/javascript/Edit/NavCards.jsx
+++ b/javascript/Edit/NavCards.jsx
@@ -1,0 +1,112 @@
+'use strict'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import './'
+
+export default class NavCards extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      currentSlide: this.props.currentSlide,
+      dragItem: -1,
+      dragLineIndex: -1,
+      addSlideHover: false
+    }
+    this.handleSlide = this.handleSlide.bind(this)
+    this.handleNewSlide = this.handleNewSlide.bind(this)
+  }
+
+  componentDidMount() {
+    document.addEventListener('dragenter', (event) => {
+      if (event.target.className === 'thumb' && Number(event.target.id) >= 0) {
+        this.setState({dragLineIndex: Number(event.target.id)})
+      }
+    })
+
+    document.addEventListener('dragstart', (event) => {
+      let img = event.target.cloneNode(true)
+      // TODO: insert custom image or logo
+      // right now i pass the slide and make it render off screen
+      event.dataTransfer.setDragImage(img, -5000, 100)
+      this.setState({dragLineIndex: this.props.currentSlide, dragItem: event.target.id})
+    }, false)
+
+    document.addEventListener('dragend', (event) => {
+      //event.target.style.display = "initial"
+      this.props.moveSlide(this.state.dragItem, this.state.dragLineIndex)
+      this.props.setCurrentSlide(this.state.dragLineIndex)
+      this.setState({dragLineIndex: -1})
+    })
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('dragenter')
+    document.removeEventListener('dragstart')
+    document.removeEventListener('dragend')
+  }
+
+  handleSlide(event) {
+    this.props.setCurrentSlide(event.target.value - 1)
+  }
+
+  handleNewSlide() {
+    this.props.addNewSlide()
+  }
+
+  render() {
+
+    let data = this.props.content.map((slide, i) => {
+      let key = (Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15)) //#1E90FF
+      let highlight = (this.props.currentSlide == i) ? ({border: 'solid 3px #007bff', borderRadius: 3, zIndex: -1}) : {padding: '3px'}
+      let top = (this.state.dragItem >= this.state.dragLineIndex)
+      let bar = (this.state.dragLineIndex != -1 && i == this.state.dragLineIndex) ? {border: 'solid 1px #1E90FF'} : {border: 'solid 1px white'}
+      return (
+        <span key={i}>
+          {top ? <div key={`a-${i}`} style={bar}></div> : undefined}
+          <div id="card" style={cardStyle} onClick={() => this.props.setCurrentSlide(i)} key={i}>
+            <img id={i} className="thumb" key={i} src={slide.thumb} width={175} height={100} alt={"loading..."} style={highlight} draggable={true}></img> 
+          </div>
+          {!top ? <div key={`b-${i}`} style={bar}></div> : undefined}
+        </span>
+      )
+    })
+
+    return (
+      <div id="container" className="col" style={containerStyle}>
+        {data}
+        <div id={this.props.content.length - 1} className="card" 
+          style={this.state.addSlideHover ? addSlideHover : addSlideStyle} 
+          onClick={this.handleNewSlide} onMouseEnter={() => this.setState({addSlideHover: true})} onMouseLeave={() => this.setState({addSlideHover: false})}>
+          Add New Slide
+          <br></br>
+          <i className="fas fa-plus-circle" style={{color: '#007bff',float: 'right', marginLeft: '44%'}}></i>
+        </div>
+      </div>
+    )
+  }
+
+}
+
+const cardStyle = {
+  width: 175, height: 100, marginBottom: 5, marginTop: 5 
+}
+
+const addSlideStyle = {
+  border: 'dashed 1px ', width: 175, height: 100, textAlign: 'center', justifyContent: 'center', color: '#007bff', marginBottom: 20, marginTop: 10
+}
+
+const addSlideHover = {
+  border: 'solid 3px', color: '007bff', width: 175, height: 100, textAlign: 'center', justifyContent: 'center', marginBottom: 20, marginTop: 10
+}
+
+const containerStyle = {
+  overflowY: 'scroll', height: 600, maxWidth: 210, marginTop: 75, scrollbarWidth: 'thin', marginBottom: 10
+}
+
+NavCards.propTypes = {
+  slides: PropTypes.array,
+  currentSlide: PropTypes.number,
+  setCurrentSlide: PropTypes.func,
+  addNewSlide: PropTypes.func,
+  moveSlide: PropTypes.func
+}

--- a/javascript/Edit/NavCards.jsx
+++ b/javascript/Edit/NavCards.jsx
@@ -72,7 +72,7 @@ export default class NavCards extends Component {
     })
 
     return (
-      <div id="container" className="col" style={containerStyle}>
+      <div id="container" className="col" style={containerStyle} onMouseEnter={() => this.props.saveDomScreen()}>
         {data}
         <div id={this.props.content.length - 1} className="card" 
           style={this.state.addSlideHover ? addSlideHover : addSlideStyle} 

--- a/javascript/Edit/Quiz/AnswerTypeCards.jsx
+++ b/javascript/Edit/Quiz/AnswerTypeCards.jsx
@@ -16,43 +16,38 @@ export default class AnswerTypeCards extends Component {
 
   render() {
     return (
-      <div style={{ padding: 10 }}>
-        <Row style={{ padding: 10, justifyContent: 'center' }} >
-          <Card bg="secondary" text="white" style={{ width: '12rem', marginRight: '1rem' }}>
-            <Card.Header>Multiple Choice</Card.Header>
-            <Card.Body>
-              <Card.Text>
-                Multiple answers for students to choose from with one correct.
-              </Card.Text>
-            </Card.Body>
-            <Card.Footer>
-              <Button id={'choice'} onClick={this.props.switchView}>Select</Button>
-            </Card.Footer>
-          </Card>
-          <Card bg="secondary" text="white" style={{ width: '12rem', marginRight: '1rem' }}>
-            <Card.Header>Open Answer</Card.Header>
-            <Card.Body>
-              <Card.Text>
-                Open text field for students to write a response.
-              </Card.Text>
-            </Card.Body>
-            <Card.Footer>
-              <Button id={'open'} onClick={this.props.switchView}>Select</Button>
-            </Card.Footer>
-          </Card>
-          <Card bg="secondary" text="white" style={{ width: '12rem' }}>
-            <Card.Header>Multiple-Select Choice</Card.Header>
-            <Card.Body>
-              <Card.Text>
-                Allow studetns to select multiple options from a multiple-choice set using radio buttons.
-              </Card.Text>
-            </Card.Body>
-            <Card.Footer>
-              <Button id={'select'} onClick={this.props.switchView}>Select</Button>
-            </Card.Footer>
-          </Card>
-        </Row>
+      <div className="row" style={{margin: 10}}>
+        <div className="col">
+          <div className="card text-center text-white bg-secondary">
+            <div className="card-header">Multiple Choice</div>
+            <div className="card-body">
+              <p className="card-text">Multiple choice options with one possible correct answer</p>
+              <br></br>
+              <button className="btn btn-primary btn-block" id="choice" onClick={this.props.switchView}>Select</button>
+            </div>
+          </div>
+        </div>
+        <div className="col">
+          <div className="card text-center text-white bg-secondary">
+            <div className="card-header">Open Answer</div>
+            <div className="card-body">
+              <p className="card-text">Open answer field for user's open response</p>
+              <br></br>
+              <button className="btn btn-primary btn-block" id="open" onClick={this.props.switchView}>Select</button>
+            </div>
+          </div>
+        </div>
+        <div className="col">
+          <div className="card text-center text-white bg-secondary">
+            <div className="card-header">Multiple Select</div>
+            <div className="card-body">
+              <p className="card-text">Multiple choice options with one or more possible correct answer(s)</p>
+              <button className="btn btn-primary btn-block" id="select" onClick={this.props.switchView}>Select</button>
+            </div>
+          </div>
+        </div>
       </div>
+      
     )
   }
 }

--- a/javascript/Edit/Quiz/MultipleChoiceBlock.jsx
+++ b/javascript/Edit/Quiz/MultipleChoiceBlock.jsx
@@ -22,8 +22,8 @@ export default class MultipleChoiceBlock extends Component {
 
   render() {
     return (
-      <Form.Row key={'row-' + this.props.id} id={this.props.id}>
-        <Form.Group controlId={'text-' + this.props.id} style={{ width: '30rem', marginRight: '1rem' }}>
+      <Form.Row key={'row-' + this.props.id} id={this.props.id} style={rowStyle}>
+        <Form.Group controlId={'text-' + this.props.id} style={{ width: '60%', marginRight: '1rem' }}>
           <Form.Control
             key={'text-' + this.props.id}
             value={this.props.value}
@@ -49,6 +49,10 @@ export default class MultipleChoiceBlock extends Component {
       </Form.Row>
     )
   }
+}
+
+const rowStyle = {
+  marginLeft: '10%'
 }
 
 MultipleChoiceBlock.propTypes = {

--- a/javascript/Edit/Quiz/MultipleSelectBlock.jsx
+++ b/javascript/Edit/Quiz/MultipleSelectBlock.jsx
@@ -17,8 +17,8 @@ export default class MultipleSelectBlock extends Component {
 
   render() {
     return (
-      <Form.Row key={'row-' + this.props.id} id={this.props.id}>
-        <Form.Group controlId={'text-' + this.props.id} style={{ width: '30rem', marginRight: '1rem' }}>
+      <Form.Row key={'row-' + this.props.id} id={this.props.id} style={rowStyle}>
+        <Form.Group controlId={'text-' + this.props.id} style={{ width: '60%', marginRight: '1rem' }}>
           <Form.Control
             key={'text-' + this.props.id}
             value={this.props.value}
@@ -45,6 +45,11 @@ export default class MultipleSelectBlock extends Component {
     )
   }
 }
+
+const rowStyle = {
+  marginLeft: '10%'
+}
+
 
 MultipleSelectBlock.propTypes = {
   id: PropTypes.number,

--- a/javascript/Edit/Quiz/QuestionTitleBlock.jsx
+++ b/javascript/Edit/Quiz/QuestionTitleBlock.jsx
@@ -35,9 +35,17 @@ export default class QuestionTitleBlock extends Component {
   render() {
     return (
       <Form.Group key={'questionTitle'} >
-        <Form.Label>Question: </Form.Label>
-        <Form.Control id={'title-' + this.props.id} value={this.state.title} onChange={this.onChange} />
+        <p style={{textAlign: 'center', marginBottom: 0}}>Question</p>
+        <Form.Control id={'title-' + this.props.id} value={this.state.title} onChange={this.onChange} style={formControlStyle}/>
       </Form.Group>
     )
   }
+}
+
+
+const formControlStyle = {
+  textAlign: 'center',
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  width: '60%'
 }

--- a/javascript/Edit/Quiz/QuizEdit.jsx
+++ b/javascript/Edit/Quiz/QuizEdit.jsx
@@ -69,8 +69,7 @@ export default class QuizEdit extends Component {
 		let nqContent = Object.assign({}, this.state.quizContent)
 
 		if (this.state.view == 'choice') {
-			if (this.state.quizContent.correctAnswers == undefined || this.state.quizContent.correctAnswers === []
-				|| nqContent.correctAnswers == false) {
+			if (this.state.quizContent.correctAnswers.length == 0) {
 				alert('Please select a correct answer')
 				return
 			}
@@ -88,8 +87,7 @@ export default class QuizEdit extends Component {
 			})
 		}
 		else if (this.state.view == 'select') {
-			if (this.state.quizContent.correctAnswers == undefined || this.state.quizContent.correctAnswers === []
-				|| nqContent.correctAnswers == false) {
+			if (this.state.quizContent.correctAnswers.length == 0) {
 				alert('Please select a correct answer(s)')
 				return
 			}
@@ -184,7 +182,7 @@ export default class QuizEdit extends Component {
 			}
 			return <MultipleChoice key={i} id={i} onChange={this.updateQuizContent} remove={this.remove} value={choice} checked={checked} />
 		})
-		choices.push(<Button key={'add'} variant="primary" onClick={this.addAnswer} style={{ marginBottom: '2rem' }}><i className="fas fa-plus-circle"></i> Add Another Answer</Button>)
+		choices.push(<Button key={'add'} variant="primary" onClick={this.addAnswer} style={{ marginBottom: '2rem', marginLeft: '10%', width: '54%' }} block><i className="fas fa-plus-circle"></i> Add Another Answer</Button>)
 		return choices
 	}
 
@@ -204,7 +202,7 @@ export default class QuizEdit extends Component {
 			let checked = (this.state.quizContent.correctAnswers.includes(i.toString()))
 			return <MultipleSelect key={i} id={i} onChange={this.updateQuizContent} remove={this.remove} value={choice} checked={checked} />
 		})
-		choices.push(<Button key={'add'} variant="primary" onClick={this.addAnswer} style={{ marginBottom: '2rem' }}><i className="fas fa-plus-circle"></i> Add Another Answer</Button>)
+		choices.push(<Button key={'add'} variant="primary" onClick={this.addAnswer} style={{ marginBottom: '2rem', marginLeft: '10%', width: '54%' }} block><i className="fas fa-plus-circle"></i> Add Another Answer</Button>)
 		return choices
 	}
 
@@ -213,7 +211,7 @@ export default class QuizEdit extends Component {
 			<AnswerTypeCards switchView={this.switchView} selectOne={this.state.quizContent.correctAnswers} />
 		) : null
 
-		let showAddElement = this.state.addElementVisible ?
+		let showAddElement = this.state.addElementVisible || this.state.view === 'showTypes' ?
 			undefined :
 			<span>
 				<Button id='showTypes' key="2" variant="secondary" onClick={this.switchView} block><i className="fas fa-undo"></i> Change Answer Type</Button>
@@ -232,13 +230,16 @@ export default class QuizEdit extends Component {
 		}
 		let title = this.state.quizContent.questionTitle
 		return (
-			<Form>
-				<h3>New Quiz:</h3>
-				<QuestionTitle value={title} onChange={this.updateQuizContent} id={0} />
-				{quizBuild}
-				{answerTypeBlock}
-				{showAddElement}
-			</Form>
+			<div>
+				<h3 style={{textAlign: 'center', marginTop: -40}}>Edit Quiz</h3>
+				<Form>
+					<QuestionTitle value={title} onChange={this.updateQuizContent} id={0} />
+					<hr style={{border: '1px solid', width: '50%'}}></hr>
+					{quizBuild}
+					{answerTypeBlock}
+					{showAddElement}
+				</Form>
+			</div>
 		)
 	}
 }

--- a/javascript/Edit/Quiz/QuizView.jsx
+++ b/javascript/Edit/Quiz/QuizView.jsx
@@ -1,9 +1,6 @@
 'use strict'
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import {
-  Button
-} from 'react-bootstrap'
 
 export default class QuizView extends Component {
   constructor(props) {
@@ -53,11 +50,10 @@ export default class QuizView extends Component {
     // Also need to handle open answers
     let title = (this.props.quizContent == undefined) ? 'No data loaded' : this.props.quizContent.questionTitle
     return (
-      <span>
+      <div>
         <h1>{title}</h1>
         {questions}
-        <Button variant="outline-primary" onClick={this.props.toggle} block><i className="fas fa-edit"></i> Edit Quiz Slide</Button>
-      </span>
+      </div>
     )
   }
 }

--- a/javascript/Edit/Toolbar/QuizToolbar.jsx
+++ b/javascript/Edit/Toolbar/QuizToolbar.jsx
@@ -7,7 +7,7 @@ export default function QuizToolbar(props) {
     <i className="fas fa-edit"></i> Edit Quiz Slide</button>)
 
   const cancel = (<button key="cancel" className="btn btn-outline-secondary btn-block"style={{ marginTop: 3 }} onClick={props.toggleQuizEdit}>
-    <i className="far fa-window-close"></i> Cancel</button>)
+    <i className="far fa-window-close"></i> Close Edit View</button>)
 
   return (
     <div>

--- a/javascript/Edit/Toolbar/QuizToolbar.jsx
+++ b/javascript/Edit/Toolbar/QuizToolbar.jsx
@@ -1,0 +1,17 @@
+'use strict'
+import React from 'react'
+
+export default function QuizToolbar(props) {
+
+  const edit = (<button key="edit" className="btn btn-outline-primary btn-block" style={{ marginTop: 3 }} onClick={props.toggleQuizEdit}>
+    <i className="fas fa-edit"></i> Edit Quiz Slide</button>)
+
+  const cancel = (<button key="cancel" className="btn btn-outline-secondary btn-block"style={{ marginTop: 3 }} onClick={props.toggleQuizEdit}>
+    <i className="far fa-window-close"></i> Cancel</button>)
+
+  return (
+    <div>
+      {props.view ? cancel : edit}
+    </div>
+  )
+}

--- a/javascript/Present/Present.jsx
+++ b/javascript/Present/Present.jsx
@@ -269,14 +269,12 @@ export default class Present extends Component {
         <h1 style={{textDecorationLine: 'underline'}}>{this.state.title}</h1>
         <br></br>
         <div style={{justifyContent: 'center', display: 'flex'}}>
-          <div style={{maxWidth: 700, width: "95%"}}>
-            <PresentView
-              currentSlide={this.state.currentSlide}
-              high={this.state.highestSlide}
-              content={this.state.content[this.state.currentSlide]}
-              validate={this.validate}
-              />
-          </div>
+          <PresentView
+            currentSlide={this.state.currentSlide}
+            high={this.state.highestSlide}
+            content={this.state.content[this.state.currentSlide]}
+            validate={this.validate}
+            />
         </div>
         <div style={{justifyContent: 'center', display: 'flex', marginBottom: '2rem'}}>
           <div className="btn-toolbar">

--- a/javascript/Present/PresentView.jsx
+++ b/javascript/Present/PresentView.jsx
@@ -25,11 +25,9 @@ export default class PresentView extends Component {
           validate={this.props.validate} />) :
         <Viewspace content={this.props.content} />
       return (
-        <div className="mh-100">
-          <div className="jumbotron" style={{minHeight: 350, backgroundColor: this.props.content.backgroundColor}}>
+          <div className="jumbotron" style={{minHeight: 400, minWidth: 800, backgroundColor: this.props.content.backgroundColor}}>
             {viewspace}
           </div>
-        </div>
       )
     }
     return null

--- a/javascript/Resources/LinkDecorator.js
+++ b/javascript/Resources/LinkDecorator.js
@@ -25,7 +25,7 @@ const Link = (props) => {
     return (
         <Tippy content={<a href={url} style={{color: 'white'}} target="_blank">{url}</a>} arrow={true} interactive={true}>
             <a className="linkDecorator" href={url} style={linkStyle} target="_blank">
-                {props.children} <i style={icon}className="fas fa-external-link-alt"></i>
+                {props.children}
             </a>
         </Tippy>
     );

--- a/javascript/Resources/dom-to-image.js
+++ b/javascript/Resources/dom-to-image.js
@@ -1,0 +1,770 @@
+(function (global) {
+    'use strict';
+
+    var util = newUtil();
+    var inliner = newInliner();
+    var fontFaces = newFontFaces();
+    var images = newImages();
+
+    // Default impl options
+    var defaultOptions = {
+        // Default is to fail on error, no placeholder
+        imagePlaceholder: undefined,
+        // Default cache bust is false, it will use the cache
+        cacheBust: false
+    };
+
+    var domtoimage = {
+        toSvg: toSvg,
+        toPng: toPng,
+        toJpeg: toJpeg,
+        toBlob: toBlob,
+        toPixelData: toPixelData,
+        impl: {
+            fontFaces: fontFaces,
+            images: images,
+            util: util,
+            inliner: inliner,
+            options: {}
+        }
+    };
+
+    if (typeof module !== 'undefined')
+        module.exports = domtoimage;
+    else
+        global.domtoimage = domtoimage;
+
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options
+     * @param {Function} options.filter - Should return true if passed node should be included in the output
+     *          (excluding node means excluding it's children as well). Not called on the root node.
+     * @param {String} options.bgcolor - color for the background, any valid CSS color value.
+     * @param {Number} options.width - width to be applied to node before rendering.
+     * @param {Number} options.height - height to be applied to node before rendering.
+     * @param {Object} options.style - an object whose properties to be copied to node's style before rendering.
+     * @param {Number} options.quality - a Number between 0 and 1 indicating image quality (applicable to JPEG only),
+                defaults to 1.0.
+     * @param {String} options.imagePlaceholder - dataURL to use as a placeholder for failed images, default behaviour is to fail fast on images we can't fetch
+     * @param {Boolean} options.cacheBust - set to true to cache bust by appending the time to the request url
+     * @return {Promise} - A promise that is fulfilled with a SVG image data URL
+     * */
+    function toSvg(node, options) {
+        options = options || {};
+        copyOptions(options);
+        return Promise.resolve(node)
+            .then(function (node) {
+                return cloneNode(node, options.filter, true);
+            })
+            .then(embedFonts)
+            .then(inlineImages)
+            .then(applyOptions)
+            .then(function (clone) {
+                return makeSvgDataUri(clone,
+                    options.width || util.width(node),
+                    options.height || util.height(node)
+                );
+            });
+
+        function applyOptions(clone) {
+            if (options.bgcolor) clone.style.backgroundColor = options.bgcolor;
+
+            if (options.width) clone.style.width = options.width + 'px';
+            if (options.height) clone.style.height = options.height + 'px';
+
+            if (options.style)
+                Object.keys(options.style).forEach(function (property) {
+                    clone.style[property] = options.style[property];
+                });
+
+            return clone;
+        }
+    }
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options, @see {@link toSvg}
+     * @return {Promise} - A promise that is fulfilled with a Uint8Array containing RGBA pixel data.
+     * */
+    function toPixelData(node, options) {
+        return draw(node, options || {})
+            .then(function (canvas) {
+                return canvas.getContext('2d').getImageData(
+                    0,
+                    0,
+                    util.width(node),
+                    util.height(node)
+                ).data;
+            });
+    }
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options, @see {@link toSvg}
+     * @return {Promise} - A promise that is fulfilled with a PNG image data URL
+     * */
+    function toPng(node, options) {
+        return draw(node, options || {})
+            .then(function (canvas) {
+                return canvas.toDataURL();
+            });
+    }
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options, @see {@link toSvg}
+     * @return {Promise} - A promise that is fulfilled with a JPEG image data URL
+     * */
+    function toJpeg(node, options) {
+        options = options || {};
+        return draw(node, options)
+            .then(function (canvas) {
+                return canvas.toDataURL('image/jpeg', options.quality || 1.0);
+            });
+    }
+
+    /**
+     * @param {Node} node - The DOM Node object to render
+     * @param {Object} options - Rendering options, @see {@link toSvg}
+     * @return {Promise} - A promise that is fulfilled with a PNG image blob
+     * */
+    function toBlob(node, options) {
+        return draw(node, options || {})
+            .then(util.canvasToBlob);
+    }
+
+    function copyOptions(options) {
+        // Copy options to impl options for use in impl
+        if(typeof(options.imagePlaceholder) === 'undefined') {
+            domtoimage.impl.options.imagePlaceholder = defaultOptions.imagePlaceholder;
+        } else {
+            domtoimage.impl.options.imagePlaceholder = options.imagePlaceholder;
+        }
+
+        if(typeof(options.cacheBust) === 'undefined') {
+            domtoimage.impl.options.cacheBust = defaultOptions.cacheBust;
+        } else {
+            domtoimage.impl.options.cacheBust = options.cacheBust;
+        }
+    }
+
+    function draw(domNode, options) {
+        return toSvg(domNode, options)
+            .then(util.makeImage)
+            .then(util.delay(100))
+            .then(function (image) {
+                var canvas = newCanvas(domNode);
+                canvas.getContext('2d').drawImage(image, 0, 0);
+                return canvas;
+            });
+
+        function newCanvas(domNode) {
+            var canvas = document.createElement('canvas');
+            canvas.width = options.width || util.width(domNode);
+            canvas.height = options.height || util.height(domNode);
+
+            if (options.bgcolor) {
+                var ctx = canvas.getContext('2d');
+                ctx.fillStyle = options.bgcolor;
+                ctx.fillRect(0, 0, canvas.width, canvas.height);
+            }
+
+            return canvas;
+        }
+    }
+
+    function cloneNode(node, filter, root) {
+        if (!root && filter && !filter(node)) return Promise.resolve();
+
+        return Promise.resolve(node)
+            .then(makeNodeCopy)
+            .then(function (clone) {
+                return cloneChildren(node, clone, filter);
+            })
+            .then(function (clone) {
+                return processClone(node, clone);
+            });
+
+        function makeNodeCopy(node) {
+            if (node instanceof HTMLCanvasElement) return util.makeImage(node.toDataURL());
+            return node.cloneNode(false);
+        }
+
+        function cloneChildren(original, clone, filter) {
+            var children = original.childNodes;
+            if (children.length === 0) return Promise.resolve(clone);
+
+            return cloneChildrenInOrder(clone, util.asArray(children), filter)
+                .then(function () {
+                    return clone;
+                });
+
+            function cloneChildrenInOrder(parent, children, filter) {
+                var done = Promise.resolve();
+                children.forEach(function (child) {
+                    done = done
+                        .then(function () {
+                            return cloneNode(child, filter);
+                        })
+                        .then(function (childClone) {
+                            if (childClone) parent.appendChild(childClone);
+                        });
+                });
+                return done;
+            }
+        }
+
+        function processClone(original, clone) {
+            if (!(clone instanceof Element)) return clone;
+
+            return Promise.resolve()
+                .then(cloneStyle)
+                .then(clonePseudoElements)
+                .then(copyUserInput)
+                .then(fixSvg)
+                .then(function () {
+                    return clone;
+                });
+
+            function cloneStyle() {
+                copyStyle(window.getComputedStyle(original), clone.style);
+
+                function copyStyle(source, target) {
+                    if (source.cssText) target.cssText = source.cssText;
+                    else copyProperties(source, target);
+
+                    function copyProperties(source, target) {
+                        util.asArray(source).forEach(function (name) {
+                            target.setProperty(
+                                name,
+                                source.getPropertyValue(name),
+                                source.getPropertyPriority(name)
+                            );
+                        });
+                    }
+                }
+            }
+
+            function clonePseudoElements() {
+                [':before', ':after'].forEach(function (element) {
+                    clonePseudoElement(element);
+                });
+
+                function clonePseudoElement(element) {
+                    var style = window.getComputedStyle(original, element);
+                    var content = style.getPropertyValue('content');
+
+                    if (content === '' || content === 'none') return;
+
+                    var className = util.uid();
+                    clone.className = clone.className + ' ' + className;
+                    var styleElement = document.createElement('style');
+                    styleElement.appendChild(formatPseudoElementStyle(className, element, style));
+                    clone.appendChild(styleElement);
+
+                    function formatPseudoElementStyle(className, element, style) {
+                        var selector = '.' + className + ':' + element;
+                        var cssText = style.cssText ? formatCssText(style) : formatCssProperties(style);
+                        return document.createTextNode(selector + '{' + cssText + '}');
+
+                        function formatCssText(style) {
+                            var content = style.getPropertyValue('content');
+                            return style.cssText + ' content: ' + content + ';';
+                        }
+
+                        function formatCssProperties(style) {
+
+                            return util.asArray(style)
+                                .map(formatProperty)
+                                .join('; ') + ';';
+
+                            function formatProperty(name) {
+                                return name + ': ' +
+                                    style.getPropertyValue(name) +
+                                    (style.getPropertyPriority(name) ? ' !important' : '');
+                            }
+                        }
+                    }
+                }
+            }
+
+            function copyUserInput() {
+                if (original instanceof HTMLTextAreaElement) clone.innerHTML = original.value;
+                if (original instanceof HTMLInputElement) clone.setAttribute("value", original.value);
+            }
+
+            function fixSvg() {
+                if (!(clone instanceof SVGElement)) return;
+                clone.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+
+                if (!(clone instanceof SVGRectElement)) return;
+                ['width', 'height'].forEach(function (attribute) {
+                    var value = clone.getAttribute(attribute);
+                    if (!value) return;
+
+                    clone.style.setProperty(attribute, value);
+                });
+            }
+        }
+    }
+
+    function embedFonts(node) {
+        return fontFaces.resolveAll()
+            .then(function (cssText) {
+                var styleNode = document.createElement('style');
+                node.appendChild(styleNode);
+                styleNode.appendChild(document.createTextNode(cssText));
+                return node;
+            });
+    }
+
+    function inlineImages(node) {
+        return images.inlineAll(node)
+            .then(function () {
+                return node;
+            });
+    }
+
+    function makeSvgDataUri(node, width, height) {
+        return Promise.resolve(node)
+            .then(function (node) {
+                node.setAttribute('xmlns', 'http://www.w3.org/1999/xhtml');
+                return new XMLSerializer().serializeToString(node);
+            })
+            .then(util.escapeXhtml)
+            .then(function (xhtml) {
+                return '<foreignObject x="0" y="0" width="100%" height="100%">' + xhtml + '</foreignObject>';
+            })
+            .then(function (foreignObject) {
+                return '<svg xmlns="http://www.w3.org/2000/svg" width="' + width + '" height="' + height + '">' +
+                    foreignObject + '</svg>';
+            })
+            .then(function (svg) {
+                return 'data:image/svg+xml;charset=utf-8,' + svg;
+            });
+    }
+
+    function newUtil() {
+        return {
+            escape: escape,
+            parseExtension: parseExtension,
+            mimeType: mimeType,
+            dataAsUrl: dataAsUrl,
+            isDataUrl: isDataUrl,
+            canvasToBlob: canvasToBlob,
+            resolveUrl: resolveUrl,
+            getAndEncode: getAndEncode,
+            uid: uid(),
+            delay: delay,
+            asArray: asArray,
+            escapeXhtml: escapeXhtml,
+            makeImage: makeImage,
+            width: width,
+            height: height
+        };
+
+        function mimes() {
+            /*
+             * Only WOFF and EOT mime types for fonts are 'real'
+             * see http://www.iana.org/assignments/media-types/media-types.xhtml
+             */
+            var WOFF = 'application/font-woff';
+            var JPEG = 'image/jpeg';
+
+            return {
+                'woff': WOFF,
+                'woff2': WOFF,
+                'ttf': 'application/font-truetype',
+                'eot': 'application/vnd.ms-fontobject',
+                'png': 'image/png',
+                'jpg': JPEG,
+                'jpeg': JPEG,
+                'gif': 'image/gif',
+                'tiff': 'image/tiff',
+                'svg': 'image/svg+xml'
+            };
+        }
+
+        function parseExtension(url) {
+            var match = /\.([^\.\/]*?)$/g.exec(url);
+            if (match) return match[1];
+            else return '';
+        }
+
+        function mimeType(url) {
+            var extension = parseExtension(url).toLowerCase();
+            return mimes()[extension] || '';
+        }
+
+        function isDataUrl(url) {
+            return url.search(/^(data:)/) !== -1;
+        }
+
+        function toBlob(canvas) {
+            return new Promise(function (resolve) {
+                var binaryString = window.atob(canvas.toDataURL().split(',')[1]);
+                var length = binaryString.length;
+                var binaryArray = new Uint8Array(length);
+
+                for (var i = 0; i < length; i++)
+                    binaryArray[i] = binaryString.charCodeAt(i);
+
+                resolve(new Blob([binaryArray], {
+                    type: 'image/png'
+                }));
+            });
+        }
+
+        function canvasToBlob(canvas) {
+            if (canvas.toBlob)
+                return new Promise(function (resolve) {
+                    canvas.toBlob(resolve);
+                });
+
+            return toBlob(canvas);
+        }
+
+        function resolveUrl(url, baseUrl) {
+            var doc = document.implementation.createHTMLDocument();
+            var base = doc.createElement('base');
+            doc.head.appendChild(base);
+            var a = doc.createElement('a');
+            doc.body.appendChild(a);
+            base.href = baseUrl;
+            a.href = url;
+            return a.href;
+        }
+
+        function uid() {
+            var index = 0;
+
+            return function () {
+                return 'u' + fourRandomChars() + index++;
+
+                function fourRandomChars() {
+                    /* see http://stackoverflow.com/a/6248722/2519373 */
+                    return ('0000' + (Math.random() * Math.pow(36, 4) << 0).toString(36)).slice(-4);
+                }
+            };
+        }
+
+        function makeImage(uri) {
+            return new Promise(function (resolve, reject) {
+                var image = new Image();
+                image.onload = function () {
+                    resolve(image);
+                };
+                image.onerror = reject;
+                image.src = uri;
+            });
+        }
+
+        function getAndEncode(url) {
+            var TIMEOUT = 30000;
+            if(domtoimage.impl.options.cacheBust) {
+                // Cache bypass so we dont have CORS issues with cached images
+                // Source: https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#Bypassing_the_cache
+                url += ((/\?/).test(url) ? "&" : "?") + (new Date()).getTime();
+            }
+
+            return new Promise(function (resolve) {
+                var request = new XMLHttpRequest();
+
+                request.onreadystatechange = done;
+                request.ontimeout = timeout;
+                request.responseType = 'blob';
+                request.timeout = TIMEOUT;
+                request.open('GET', url, true);
+                request.send();
+
+                var placeholder;
+                if(domtoimage.impl.options.imagePlaceholder) {
+                    var split = domtoimage.impl.options.imagePlaceholder.split(/,/);
+                    if(split && split[1]) {
+                        placeholder = split[1];
+                    }
+                }
+
+                function done() {
+                    if (request.readyState !== 4) return;
+
+                    if (request.status !== 200) {
+                        if(placeholder) {
+                            resolve(placeholder);
+                        } else {
+                            fail('cannot fetch resource: ' + url + ', status: ' + request.status);
+                        }
+
+                        return;
+                    }
+
+                    var encoder = new FileReader();
+                    encoder.onloadend = function () {
+                        var content = encoder.result.split(/,/)[1];
+                        resolve(content);
+                    };
+                    encoder.readAsDataURL(request.response);
+                }
+
+                function timeout() {
+                    if(placeholder) {
+                        resolve(placeholder);
+                    } else {
+                        fail('timeout of ' + TIMEOUT + 'ms occured while fetching resource: ' + url);
+                    }
+                }
+
+                function fail(message) {
+                    console.error(message);
+                    resolve('');
+                }
+            });
+        }
+
+        function dataAsUrl(content, type) {
+            return 'data:' + type + ';base64,' + content;
+        }
+
+        function escape(string) {
+            return string.replace(/([.*+?^${}()|\[\]\/\\])/g, '\\$1');
+        }
+
+        function delay(ms) {
+            return function (arg) {
+                return new Promise(function (resolve) {
+                    setTimeout(function () {
+                        resolve(arg);
+                    }, ms);
+                });
+            };
+        }
+
+        function asArray(arrayLike) {
+            var array = [];
+            var length = arrayLike.length;
+            for (var i = 0; i < length; i++) array.push(arrayLike[i]);
+            return array;
+        }
+
+        function escapeXhtml(string) {
+            return string.replace(/#/g, '%23').replace(/\n/g, '%0A');
+        }
+
+        function width(node) {
+            var leftBorder = px(node, 'border-left-width');
+            var rightBorder = px(node, 'border-right-width');
+            return node.scrollWidth + leftBorder + rightBorder;
+        }
+
+        function height(node) {
+            var topBorder = px(node, 'border-top-width');
+            var bottomBorder = px(node, 'border-bottom-width');
+            return node.scrollHeight + topBorder + bottomBorder;
+        }
+
+        function px(node, styleProperty) {
+            var value = window.getComputedStyle(node).getPropertyValue(styleProperty);
+            return parseFloat(value.replace('px', ''));
+        }
+    }
+
+    function newInliner() {
+        var URL_REGEX = /url\(['"]?([^'"]+?)['"]?\)/g;
+
+        return {
+            inlineAll: inlineAll,
+            shouldProcess: shouldProcess,
+            impl: {
+                readUrls: readUrls,
+                inline: inline
+            }
+        };
+
+        function shouldProcess(string) {
+            return string.search(URL_REGEX) !== -1;
+        }
+
+        function readUrls(string) {
+            var result = [];
+            var match;
+            while ((match = URL_REGEX.exec(string)) !== null) {
+                result.push(match[1]);
+            }
+            return result.filter(function (url) {
+                return !util.isDataUrl(url);
+            });
+        }
+
+        function inline(string, url, baseUrl, get) {
+            return Promise.resolve(url)
+                .then(function (url) {
+                    return baseUrl ? util.resolveUrl(url, baseUrl) : url;
+                })
+                .then(get || util.getAndEncode)
+                .then(function (data) {
+                    return util.dataAsUrl(data, util.mimeType(url));
+                })
+                .then(function (dataUrl) {
+                    return string.replace(urlAsRegex(url), '$1' + dataUrl + '$3');
+                });
+
+            function urlAsRegex(url) {
+                return new RegExp('(url\\([\'"]?)(' + util.escape(url) + ')([\'"]?\\))', 'g');
+            }
+        }
+
+        function inlineAll(string, baseUrl, get) {
+            if (nothingToInline()) return Promise.resolve(string);
+
+            return Promise.resolve(string)
+                .then(readUrls)
+                .then(function (urls) {
+                    var done = Promise.resolve(string);
+                    urls.forEach(function (url) {
+                        done = done.then(function (string) {
+                            return inline(string, url, baseUrl, get);
+                        });
+                    });
+                    return done;
+                });
+
+            function nothingToInline() {
+                return !shouldProcess(string);
+            }
+        }
+    }
+
+    function newFontFaces() {
+        return {
+            resolveAll: resolveAll,
+            impl: {
+                readAll: readAll
+            }
+        };
+
+        function resolveAll() {
+            return readAll(document)
+                .then(function (webFonts) {
+                    return Promise.all(
+                        webFonts.map(function (webFont) {
+                            return webFont.resolve();
+                        })
+                    );
+                })
+                .then(function (cssStrings) {
+                    return cssStrings.join('\n');
+                });
+        }
+
+        function readAll() {
+            return Promise.resolve(util.asArray(document.styleSheets))
+                .then(getCssRules)
+                .then(selectWebFontRules)
+                .then(function (rules) {
+                    return rules.map(newWebFont);
+                });
+
+            function selectWebFontRules(cssRules) {
+                return cssRules
+                    .filter(function (rule) {
+                        return rule.type === CSSRule.FONT_FACE_RULE;
+                    })
+                    .filter(function (rule) {
+                        return inliner.shouldProcess(rule.style.getPropertyValue('src'));
+                    });
+            }
+
+            function getCssRules(styleSheets) {
+                var cssRules = [];
+                styleSheets.forEach(function (sheet) {
+                    try {
+                        util.asArray(sheet.cssRules || []).forEach(cssRules.push.bind(cssRules));
+                    } catch (e) {
+                        // Google's css doesn't like this -> which throws this error everytime
+                        //console.log('Error while reading CSS rules from ' + sheet.href, e.toString());
+                    }
+                });
+                return cssRules;
+            }
+
+            function newWebFont(webFontRule) {
+                return {
+                    resolve: function resolve() {
+                        var baseUrl = (webFontRule.parentStyleSheet || {}).href;
+                        return inliner.inlineAll(webFontRule.cssText, baseUrl);
+                    },
+                    src: function () {
+                        return webFontRule.style.getPropertyValue('src');
+                    }
+                };
+            }
+        }
+    }
+
+    function newImages() {
+        return {
+            inlineAll: inlineAll,
+            impl: {
+                newImage: newImage
+            }
+        };
+
+        function newImage(element) {
+            return {
+                inline: inline
+            };
+
+            function inline(get) {
+                if (util.isDataUrl(element.src)) return Promise.resolve();
+
+                return Promise.resolve(element.src)
+                    .then(get || util.getAndEncode)
+                    .then(function (data) {
+                        return util.dataAsUrl(data, util.mimeType(element.src));
+                    })
+                    .then(function (dataUrl) {
+                        return new Promise(function (resolve, reject) {
+                            element.onload = resolve;
+                            element.onerror = reject;
+                            element.src = dataUrl;
+                        });
+                    });
+            }
+        }
+
+        function inlineAll(node) {
+            if (!(node instanceof Element)) return Promise.resolve(node);
+
+            return inlineBackground(node)
+                .then(function () {
+                    if (node instanceof HTMLImageElement)
+                        return newImage(node).inline();
+                    else
+                        return Promise.all(
+                            util.asArray(node.childNodes).map(function (child) {
+                                return inlineAll(child);
+                            })
+                        );
+                });
+
+            function inlineBackground(node) {
+                var background = node.style.getPropertyValue('background');
+
+                if (!background) return Promise.resolve(node);
+
+                return inliner.inlineAll(background)
+                    .then(function (inlined) {
+                        node.style.setProperty(
+                            'background',
+                            inlined,
+                            node.style.getPropertyPriority('background')
+                        );
+                    })
+                    .then(function () {
+                        return node;
+                    });
+            }
+        }
+    }
+})(this);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slideshow",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "description": "Slideshow-based modules with quiz integration",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
# In this pull request
* Replaced SlidesView with rendered previews of each slide!!! (NavCards)
    * Can now reorder slides by clicking and dragging 
    * NavCards is scroll-able, meaning that it doesn't expand the page if there are a lot of slides 
    * This was all made possible with [domtoimage](https://github.com/tsayen/dom-to-image) 
    * The preview image gets rendered on a save and when the mouse enters the NavCard container. I did it this way so that the image witll be up to date with any change to what slide you are on.
* Quiz ui and minor bugs 
    * Fixed small bug where selecting the first option as a correct answer wasn't registering on save
    * Moved Edit bar outside the component to where the Toolbar location
    * Replaced react-boostrap with raw boostrap with QuizType cards
* Misc
    * Removed link icon on the link decorator 
    * Adjusted sizing of the editor within edit and present (bigger is better)
    * Made the editor more fluid
# Not in this pull request
* Pure fluidity for the editor
    * When editing in a really small window, The Navcards move above the editor, which looks wonkey. It would look nice if they shifted to horizontal. Maybe using something like [this](https://www.w3schools.com/css/tryit.asp?filename=trycss3_flexbox_image_gallery)
* Automatic scrolling when selecting a card that isn't fully appearing. 
    * This may not be hard to implement
* Tooltip or preview image when dragging a slide to reorder