### PR TITLE
Added loading skeleton to edit to prevent async bugs

### DIFF
--- a/javascript/Edit/Edit.jsx
+++ b/javascript/Edit/Edit.jsx
@@ -11,6 +11,7 @@ import {
 
 import { fetchQuiz, postQuiz } from '../api/quiz'
 import domtoimage from '../Resources/dom-to-image'
+import Skeleton from '../Resources/Components/Skeleton.jsx'
 
 export default class Edit extends Component {
   constructor() {
@@ -33,6 +34,7 @@ export default class Edit extends Component {
         },
       ],
       slideTimer: 2,
+      loaded: false
     }
 
 
@@ -129,7 +131,8 @@ export default class Edit extends Component {
           }
           this.setState({
             content: showContent,
-            id: loaded[0].showId
+            id: loaded[0].showId,
+            loaded: true
           });
         }
         else {
@@ -367,6 +370,7 @@ export default class Edit extends Component {
 
 
   render() {
+    if (!this.state.loaded) return <Skeleton />
     let isQuiz = this.quizConv(this.state.content[this.state.currentSlide].isQuiz)
     let cardTitle;
     if (this.state.editTitleView) {

--- a/javascript/Edit/Edit.jsx
+++ b/javascript/Edit/Edit.jsx
@@ -137,6 +137,7 @@ export default class Edit extends Component {
         }
         else {
           this.save()
+          this.setState({loaded: true})
         }
       }.bind(this),
       error: function(req, err) {

--- a/javascript/Present/Navbar.jsx
+++ b/javascript/Present/Navbar.jsx
@@ -118,23 +118,6 @@ export const Progress = (props) => {
     )
 }
 
-export const Skeleton = () => {
-    return (
-        <div className="text-center" style={spinner}>
-            <p>Loading show...</p>
-            <div className="spinner-border text-primary" style={{width: '3rem', height: '3rem'}} role="status">
-                <span className="sr-only">Loading...</span>
-            </div>
-        </div>
-    )
-}
-
 const buttonGroup = {
     justifyContent: 'center', display: 'flex', marginBottom: '1rem'
-}
-
-const spinner = {
-    marginRight: 'auto',
-    marginLeft: 'auto',
-    marginTop: '10rem',
 }

--- a/javascript/Present/Present.jsx
+++ b/javascript/Present/Present.jsx
@@ -5,7 +5,8 @@ import { fetchShow, fetchSlides, fetchSession, updateSession, slidesResource } f
 
 import PresentView from './PresentView'
 
-import { Progress, Navigation, Skeleton, Finish, SlidesNav } from './Navbar'
+import { Progress, Navigation, Finish, SlidesNav } from './Navbar'
+import Skeleton from '../Resources/Components/Skeleton'
 
 export default function Present() {
     

--- a/javascript/Resources/Components/Skeleton.jsx
+++ b/javascript/Resources/Components/Skeleton.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+export default function Skeleton(props) {
+    const title = (props.title === undefined) ? "Loading show..." : props.title
+    return (
+        <div className="text-center" style={spinner}>
+            <p>{title}</p>
+            <div className="spinner-border text-primary" style={{width: '3rem', height: '3rem'}} role="status">
+                <span className="sr-only">Loading...</span>
+            </div>
+        </div>
+    )
+}
+
+const spinner = {
+    marginRight: 'auto',
+    marginLeft: 'auto',
+    marginTop: '10rem',
+}


### PR DESCRIPTION
This small change is essential with preventing bugs. It mainly addresses the issue where the preview image for the first slide doesn't load correctly because the slide data hasn't loaded yet. This update now prevents all subcomponents from rendering until the slide data has finished loading from the database call.